### PR TITLE
Remove comment from status bar button

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,7 +109,7 @@ func getStatusBar(lanes *Lanes, mode string) *tview.Flex {
 	bExit.SetBackgroundColor(tcell.ColorLightGray)
 	bExit.SetSelectedFunc(lanes.CmdExit)
 
-	bMode := tview.NewButton("[blue::-]" + mode) // [blue::-]F12
+	bMode := tview.NewButton("[blue::-]" + mode)
 	bMode.SetBackgroundColor(tcell.ColorLightGray)
 	bMode.SetSelectedFunc(lanes.CmdSelectModeDialog)
 


### PR DESCRIPTION
## Summary
- clean up UI status bar code by removing leftover comment for F12 button

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68466fb502748330be66d50dcb6c751e