### PR TITLE
Fix error propagation in ListValidModesRemoveProvided

### DIFF
--- a/cmd/ui_modes.go
+++ b/cmd/ui_modes.go
@@ -13,7 +13,10 @@ import (
 
 func (l *Lanes) ListValidModesRemoveProvided(activeMode string) ([]string, int, error) {
 	res := make([]string, 0)
-	modes, activeModeIndex, _ := l.ListValidModes(activeMode)
+	modes, activeModeIndex, err := l.ListValidModes(activeMode)
+	if err != nil {
+		return nil, 0, err
+	}
 	for _, m := range modes {
 		if m != activeMode {
 			res = append(res, m)


### PR DESCRIPTION
## Summary
- capture error from `ListValidModes` in `ListValidModesRemoveProvided`
- return nil results and the error to caller if listing fails

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68466fa7db808330a3f39763118ba46a