### PR TITLE
Implement version check

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,10 +1,16 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+var checkLatest bool
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
@@ -12,10 +18,93 @@ var versionCmd = &cobra.Command{
 	Long:  `prints version info based on CI/CD pipeline info, used within 'build.sh'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println(AppVersion)
+		if checkLatest {
+			if err := checkForNewVersion(); err != nil {
+				return err
+			}
+		}
 		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	versionCmd.Flags().BoolVarP(&checkLatest, "check", "c", false, "check for newer release")
+}
+
+func checkForNewVersion() error {
+	tag, err := getLatestReleaseTag()
+	if err != nil {
+		return err
+	}
+	newer, err := isReleaseNewer(tag, AppVersion)
+	if err != nil {
+		return err
+	}
+	if newer {
+		fmt.Printf("A newer version %s is available. View releases at https://github.com/cklukas/todo/releases\n", tag)
+	}
+	return nil
+}
+
+func getLatestReleaseTag() (string, error) {
+	resp, err := http.Get("https://api.github.com/repos/cklukas/todo/releases/latest")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var data struct {
+		Tag string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", err
+	}
+	return data.Tag, nil
+}
+
+func versionParts(v string) ([]int, error) {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.Split(v, ".")
+	res := make([]int, len(parts))
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = n
+	}
+	return res, nil
+}
+
+func isReleaseNewer(release, current string) (bool, error) {
+	r, err := versionParts(release)
+	if err != nil {
+		return false, err
+	}
+	c, err := versionParts(current)
+	if err != nil {
+		return false, err
+	}
+	l := len(r)
+	if len(c) > l {
+		l = len(c)
+	}
+	for i := 0; i < l; i++ {
+		rv, cv := 0, 0
+		if i < len(r) {
+			rv = r[i]
+		}
+		if i < len(c) {
+			cv = c[i]
+		}
+		if rv > cv {
+			return true, nil
+		} else if rv < cv {
+			return false, nil
+		}
+	}
+	return false, nil
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import "testing"
+
+func TestIsReleaseNewer(t *testing.T) {
+	tests := []struct {
+		release string
+		current string
+		newer   bool
+	}{
+		{"v1.0.14", "1.0.13", true},
+		{"v1.2.0", "1.2", false},
+		{"v2.0.0", "1.9.9", true},
+		{"v1.0.9", "1.1.0", false},
+		{"v1.0.10", "1.0.9", true},
+	}
+	for _, tc := range tests {
+		got, err := isReleaseNewer(tc.release, tc.current)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != tc.newer {
+			t.Errorf("isReleaseNewer(%s,%s)=%v expected %v", tc.release, tc.current, got, tc.newer)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `--check` flag to `version` command
- look up latest GitHub release when `--check` is used
- compare release version against current app version
- notify user when a newer release is available
- test version comparison logic

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68467f13c89c8330b4fcb2f220af0e6d