### PR TITLE
Handle local development version

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,21 +1,249 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/user"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
 )
+
+var checkLatest bool
+var updateApp bool
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "print version info",
 	Long:  `prints version info based on CI/CD pipeline info, used within 'build.sh'`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println(AppVersion)
+		v := AppVersion
+		if isLocalDevelopmentVersion(AppVersion) {
+			v += " (local development version)"
+		}
+		fmt.Println(v)
+		if updateApp {
+			return updateToLatest()
+		}
+		if checkLatest {
+			if err := checkForNewVersion(); err != nil {
+				return err
+			}
+		}
 		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	versionCmd.Flags().BoolVarP(&checkLatest, "check", "c", false, "check for newer release")
+	versionCmd.Flags().BoolVarP(&updateApp, "update", "u", false, "download latest release")
+}
+
+func checkForNewVersion() error {
+	tag, err := getLatestReleaseTag()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Latest release: %s\n", tag)
+	newer, err := isReleaseNewer(tag, AppVersion)
+	if err == nil && newer {
+		fmt.Printf("A newer version %s is available. View releases at https://github.com/cklukas/todo/releases\n", tag)
+	}
+	return nil
+}
+
+func getLatestReleaseTag() (string, error) {
+	resp, err := http.Get("https://api.github.com/repos/cklukas/todo/releases/latest")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var data struct {
+		Tag string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", err
+	}
+	return data.Tag, nil
+}
+
+func versionParts(v string) ([]int, error) {
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return []int{0}, nil
+	}
+	parts := strings.Split(v, ".")
+	res := make([]int, len(parts))
+	for i, p := range parts {
+		if p == "" {
+			res[i] = 0
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = n
+	}
+	return res, nil
+}
+
+func isReleaseNewer(release, current string) (bool, error) {
+	r, err := versionParts(release)
+	if err != nil {
+		return false, err
+	}
+	c, err := versionParts(current)
+	if err != nil {
+		return false, err
+	}
+	l := len(r)
+	if len(c) > l {
+		l = len(c)
+	}
+	for i := 0; i < l; i++ {
+		rv, cv := 0, 0
+		if i < len(r) {
+			rv = r[i]
+		}
+		if i < len(c) {
+			cv = c[i]
+		}
+		if rv > cv {
+			return true, nil
+		} else if rv < cv {
+			return false, nil
+		}
+	}
+	return false, nil
+}
+
+func isLocalDevelopmentVersion(v string) bool {
+	return v == "" || strings.Contains(v, "..")
+}
+
+func assetNameForCurrentOS() (string, error) {
+	switch runtime.GOOS {
+	case "windows":
+		if runtime.GOARCH == "amd64" {
+			return "todo.exe", nil
+		}
+	case "linux":
+		if runtime.GOARCH == "amd64" {
+			return "todo_linux_amd64", nil
+		}
+		if runtime.GOARCH == "arm64" {
+			return "todo_linux_arm64", nil
+		}
+	case "darwin":
+		if runtime.GOARCH == "arm64" {
+			return "todo_mac_arm64", nil
+		}
+	}
+	return "", fmt.Errorf("unsupported OS/ARCH combination %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
+func updateToLatest() error {
+	tag, err := getLatestReleaseTag()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Latest release: %s\n", tag)
+	newer, err := isReleaseNewer(tag, AppVersion)
+	if err != nil {
+		return err
+	}
+	if !newer {
+		fmt.Println("Already on latest version")
+		return nil
+	}
+
+	asset, err := assetNameForCurrentOS()
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("https://github.com/cklukas/todo/releases/download/%s/%s", tag, asset)
+	tmp, err := os.CreateTemp("", asset+"__"+strings.TrimPrefix(tag, "v"))
+	if err != nil {
+		return err
+	}
+	defer tmp.Close()
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed: %s", resp.Status)
+	}
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		return err
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Downloaded new version to %s\n", tmp.Name())
+	printUpdateInstructions(tmp.Name(), exe)
+	return nil
+}
+
+func printUpdateInstructions(tmp, exe string) {
+	switch runtime.GOOS {
+	case "windows":
+		fmt.Printf("To update, run (in a terminal with administrator rights):\n  copy /Y %s %s\n", tmp, exe)
+	default:
+		writable := fileWritable(exe)
+		if writable {
+			fmt.Printf("To update, run:\n  cp %s %s\n  chmod +x %s\n", tmp, exe, exe)
+		} else {
+			fmt.Printf("To update, run:\n  sudo cp %s %s\n  sudo chmod +x %s\n", tmp, exe, exe)
+		}
+	}
+}
+
+func fileWritable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	mode := info.Mode().Perm()
+	if runtime.GOOS == "windows" {
+		// On Windows rely on the write bits only.
+		return mode&0222 != 0
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return mode&0222 != 0
+	}
+	uid := os.Getuid()
+	if int(st.Uid) == uid && mode&0200 != 0 {
+		return true
+	}
+	usr, err := user.Current()
+	if err == nil {
+		gids, _ := usr.GroupIds()
+		for _, g := range gids {
+			gid, _ := strconv.Atoi(g)
+			if int(st.Gid) == gid && mode&0020 != 0 {
+				return true
+			}
+		}
+	} else if int(st.Gid) == os.Getgid() && mode&0020 != 0 {
+		return true
+	}
+	if mode&0002 != 0 {
+		return true
+	}
+	return false
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestIsReleaseNewer(t *testing.T) {
+	tests := []struct {
+		release string
+		current string
+		newer   bool
+	}{
+		{"v1.0.14", "1.0.13", true},
+		{"v1.2.0", "1.2", false},
+		{"v2.0.0", "1.9.9", true},
+		{"v1.0.9", "1.1.0", false},
+		{"v1.0.10", "1.0.9", true},
+		{"v1.0.14", "1..", true},
+	}
+	for _, tc := range tests {
+		got, err := isReleaseNewer(tc.release, tc.current)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != tc.newer {
+			t.Errorf("isReleaseNewer(%s,%s)=%v expected %v", tc.release, tc.current, got, tc.newer)
+		}
+	}
+}
+
+func TestLocalDevelopmentVersion(t *testing.T) {
+	if !isLocalDevelopmentVersion("1..") {
+		t.Errorf("expected local development version")
+	}
+	if isLocalDevelopmentVersion("1.0.0") {
+		t.Errorf("did not expect local development version")
+	}
+	parts, err := versionParts("1..")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{1, 0, 0}
+	for i, v := range expected {
+		if parts[i] != v {
+			t.Errorf("expected part %d to be %d got %d", i, v, parts[i])
+		}
+	}
+}
+
+func TestAssetNameForCurrentOS(t *testing.T) {
+	asset, err := assetNameForCurrentOS()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" && asset != "todo_linux_amd64" {
+		t.Errorf("unexpected asset name %s", asset)
+	}
+}
+
+func TestFileWritable(t *testing.T) {
+	tmp, err := os.CreateTemp("", "fw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+	if !fileWritable(tmp.Name()) {
+		t.Errorf("expected file to be writable")
+	}
+	os.Chmod(tmp.Name(), 0444)
+	if fileWritable(tmp.Name()) {
+		t.Errorf("expected file to be non writable")
+	}
+	os.Chmod(tmp.Name(), 0666)
+	if !fileWritable(tmp.Name()) {
+		t.Errorf("expected file to be writable with world permissions")
+	}
+}


### PR DESCRIPTION
## Summary
- mark version as "(local development version)" when `AppVersion` indicates a local build
- always print the latest GitHub release when `--check` is used
- compare versions even when segments are missing
- add `--update` flag to download the latest release and provide update instructions
- test version comparison, local development detection and new helpers
- improve writable check for update instructions

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68467f13c89c8330b4fcb2f220af0e6d