### PR TITLE
Fix windows build and cross compile

### DIFF
--- a/cmd/file_writable_unix.go
+++ b/cmd/file_writable_unix.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+// fileWritable reports whether the given path is writable by the current user on Unix-like systems.
+func fileWritable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	mode := info.Mode().Perm()
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return mode&0222 != 0
+	}
+	uid := os.Getuid()
+	if int(st.Uid) == uid && mode&0200 != 0 {
+		return true
+	}
+	usr, err := user.Current()
+	if err == nil {
+		gids, _ := usr.GroupIds()
+		for _, g := range gids {
+			gid, _ := strconv.Atoi(g)
+			if int(st.Gid) == gid && mode&0020 != 0 {
+				return true
+			}
+		}
+	} else if int(st.Gid) == os.Getgid() && mode&0020 != 0 {
+		return true
+	}
+	if mode&0002 != 0 {
+		return true
+	}
+	return false
+}

--- a/cmd/file_writable_windows.go
+++ b/cmd/file_writable_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package cmd
+
+import "os"
+
+// fileWritable reports whether the given path is writable by the current user on Windows.
+// It only checks the write permission bits because Windows does not expose POSIX UID/GID.
+func fileWritable(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	mode := info.Mode().Perm()
+	return mode&0222 != 0
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,11 +6,9 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/user"
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/spf13/cobra"
 )
@@ -210,40 +208,4 @@ func printUpdateInstructions(tmp, exe string) {
 			fmt.Printf("To update, run:\n  sudo cp %s %s\n  sudo chmod +x %s\n", tmp, exe, exe)
 		}
 	}
-}
-
-func fileWritable(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	mode := info.Mode().Perm()
-	if runtime.GOOS == "windows" {
-		// On Windows rely on the write bits only.
-		return mode&0222 != 0
-	}
-	st, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return mode&0222 != 0
-	}
-	uid := os.Getuid()
-	if int(st.Uid) == uid && mode&0200 != 0 {
-		return true
-	}
-	usr, err := user.Current()
-	if err == nil {
-		gids, _ := usr.GroupIds()
-		for _, g := range gids {
-			gid, _ := strconv.Atoi(g)
-			if int(st.Gid) == gid && mode&0020 != 0 {
-				return true
-			}
-		}
-	} else if int(st.Gid) == os.Getgid() && mode&0020 != 0 {
-		return true
-	}
-	if mode&0002 != 0 {
-		return true
-	}
-	return false
 }

--- a/test.sh
+++ b/test.sh
@@ -2,3 +2,11 @@
 set -e
 
 go test ./...
+
+# Ensure the code builds for all target platforms.
+targets=("linux/amd64" "linux/arm64" "darwin/arm64" "windows/amd64")
+for t in "${targets[@]}"; do
+    IFS=/ read -r os arch <<<"$t"
+    echo "building for $os/$arch"
+    env GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o /tmp/todo_test_$os_$arch .
+done


### PR DESCRIPTION
## Summary
- fix windows build by splitting fileWritable into platform files
- add cross-platform compile checks to test script

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68468a9ff71483309bf9a1085a6d721a