### PR TITLE
Add priority feature with additional info lines

### DIFF
--- a/cmd/contents.go
+++ b/cmd/contents.go
@@ -130,7 +130,7 @@ func (c *ToDoContent) ArchiveItem(lane, idx int) error {
 	return nil
 }
 
-func (c *ToDoContent) AddItem(lane, idx int, title string, secondary string) {
+func (c *ToDoContent) AddItem(lane, idx int, title string, secondary string, priority int, due string) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	usr, err := user.Current()
 	userName := ""
@@ -143,11 +143,11 @@ func (c *ToDoContent) AddItem(lane, idx int, title string, secondary string) {
 		Secondary:     secondary,
 		Note:          "",
 		Guid:          uuid.NewString(),
-		Priority:      0,
+		Priority:      priority,
 		IsArchived:    false,
 		Created:       now,
 		LastUpdate:    now,
-		Due:           "",
+		Due:           due,
 		UserName:      userName,
 		UpdatedByName: userName,
 		Mode:          "",

--- a/cmd/contents_test.go
+++ b/cmd/contents_test.go
@@ -20,7 +20,7 @@ func TestInsertNewLane(t *testing.T) {
 func TestMoveItem(t *testing.T) {
 	c := &ToDoContent{}
 	c.InitializeNew()
-	c.AddItem(0, 0, "task", "")
+	c.AddItem(0, 0, "task", "", 2, "")
 	c.MoveItem(0, 0, 1, 0)
 	if len(c.Items[0]) != 0 {
 		t.Fatalf("item not removed from source")
@@ -46,10 +46,28 @@ func TestRemoveLane(t *testing.T) {
 func TestGetLaneTitle(t *testing.T) {
 	c := &ToDoContent{}
 	c.InitializeNew()
-	c.AddItem(0, 0, "task", "")
+	c.AddItem(0, 0, "task", "", 2, "")
 	title := c.GetLaneTitle(0)
 	if title != " To Do (1) " {
 		t.Fatalf("unexpected title: %s", title)
+	}
+}
+
+func TestAddItemPriority(t *testing.T) {
+	c := &ToDoContent{}
+	c.InitializeNew()
+	c.AddItem(0, 0, "p task", "", 3, "")
+	if c.Items[0][0].Priority != 3 {
+		t.Fatalf("expected priority 3 got %d", c.Items[0][0].Priority)
+	}
+}
+
+func TestAddItemDue(t *testing.T) {
+	c := &ToDoContent{}
+	c.InitializeNew()
+	c.AddItem(0, 0, "due task", "", 2, "2025-06-10")
+	if c.Items[0][0].Due != "2025-06-10" {
+		t.Fatalf("expected due 2025-06-10 got %s", c.Items[0][0].Due)
 	}
 }
 

--- a/cmd/due_test.go
+++ b/cmd/due_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "testing"
+import "time"
+
+func TestDueSuffix(t *testing.T) {
+	now := time.Date(2025, 6, 10, 10, 0, 0, 0, time.UTC)
+	if s := dueSuffix("2025-06-10", now); s != "[due!]" {
+		t.Fatalf("expected [due!] got %s", s)
+	}
+	if s := dueSuffix("2025-06-11", now); s != "[tomorrow]" {
+		t.Fatalf("expected [tomorrow] got %s", s)
+	}
+	if s := dueSuffix("2025-06-12", now); s != "" {
+		t.Fatalf("expected empty suffix got %s", s)
+	}
+}

--- a/cmd/ui_lanes.go
+++ b/cmd/ui_lanes.go
@@ -158,7 +158,9 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 			if len(text) == 0 {
 				text = "(empty)"
 			}
-			l.content.AddItem(l.active, item, text, secondary)
+			prio := l.add.GetPriority()
+			due := l.add.GetDueISO()
+			l.content.AddItem(l.active, item, text, secondary, prio, due)
 			l.redrawLane(l.active, item)
 			content.Save()
 		}
@@ -183,6 +185,8 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 			itemVal := l.currentItem()
 			itemVal.Title = text
 			itemVal.Secondary = secondary
+			itemVal.Priority = l.edit.GetPriority()
+			itemVal.Due = l.edit.GetDueISO()
 			itemVal.LastUpdate = time.Now().UTC().Format(time.RFC3339)
 			if usr, err := user.Current(); err == nil {
 				itemVal.UpdatedByName = usr.Username


### PR DESCRIPTION
## Summary
- support priority selection via dropdown in item dialogs
- display created/modified meta info when editing
- allow AddItem to set priority
- adjust UI to save priority when adding/editing tasks
- update tests for new priority logic
- add due date editing and highlight tasks due soon

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6846903df8d08330a32a5fc8eab5b199