### PR TITLE
Add version info to About dialog

### DIFF
--- a/cmd/ui_lanes.go
+++ b/cmd/ui_lanes.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 	"os/user"
 	"time"
 
@@ -98,8 +99,18 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 
 	// help := tview.NewModal().
 	help := tview.NewModal()
+	aboutText := fmt.Sprintf("Version: %s", AppVersion)
+	if isLocalDevelopmentVersion(AppVersion) {
+		aboutText += " (local development version)"
+	}
+	aboutText += "\n- developed by C. Klukas -\n\n- adapted from toukan (https://github.com/witchard/toukan) -\n\nUsage/Keys:\nEnter/space - mark task, cursor keys - move marked task, +/Insert - add, e - edit, Del/d - delete task, n - note, a - archive, Tab - switch lane, m - select mode, q - quit"
+	if tag, newer, err := latestReleaseInfo(AppVersion); err == nil && newer {
+		if exe, err := os.Executable(); err == nil {
+			aboutText += fmt.Sprintf("\n\nA newer version %s is available.\nUse \"%s version --update\" to update.", tag, exe)
+		}
+	}
 	help = help.
-		SetText("- developed by C. Klukas -\n\n- adapted from toukan (https://github.com/witchard/toukan) -\n\nUsage/Keys:\nEnter/space - mark task, cursor keys - move marked task, +/Insert - add, e - edit, Del/d - delete task, n - note, a - archive, Tab - switch lane, m - select mode, q - quit").
+		SetText(aboutText).
 		AddButtons([]string{"OK"}).
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 			l.pages.HidePage("help")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,8 @@ import (
 var checkLatest bool
 var updateApp bool
 
+var latestReleaseURL = "https://api.github.com/repos/cklukas/todo/releases/latest"
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "print version info",
@@ -45,20 +47,31 @@ func init() {
 }
 
 func checkForNewVersion() error {
-	tag, err := getLatestReleaseTag()
+	tag, newer, err := latestReleaseInfo(AppVersion)
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Latest release: %s\n", tag)
-	newer, err := isReleaseNewer(tag, AppVersion)
-	if err == nil && newer {
+	if newer {
 		fmt.Printf("A newer version %s is available. View releases at https://github.com/cklukas/todo/releases\n", tag)
 	}
 	return nil
 }
 
+func latestReleaseInfo(current string) (string, bool, error) {
+	tag, err := getLatestReleaseTag()
+	if err != nil {
+		return "", false, err
+	}
+	newer, err := isReleaseNewer(tag, current)
+	if err != nil {
+		return tag, false, err
+	}
+	return tag, newer, nil
+}
+
 func getLatestReleaseTag() (string, error) {
-	resp, err := http.Get("https://api.github.com/repos/cklukas/todo/releases/latest")
+	resp, err := http.Get(latestReleaseURL)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- display version and update instructions in the About dialog
- add reusable `latestReleaseInfo` helper
- expose update check in About dialog
- allow overriding GitHub URL for tests
- test the new helper using a local server

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846cb07d44083308f9aacdad84a951a