### PR TITLE
Improve modal dialogs and due date input

### DIFF
--- a/cmd/due_test.go
+++ b/cmd/due_test.go
@@ -15,3 +15,20 @@ func TestDueSuffix(t *testing.T) {
 		t.Fatalf("expected empty suffix got %s", s)
 	}
 }
+
+func TestFormatDueInput(t *testing.T) {
+	cases := map[string]string{
+		"1":          "1",
+		"12":         "12.",
+		"120":        "12.0",
+		"1203":       "12.03",
+		"120320":     "12.03.20",
+		"12032023":   "12.03.2023",
+		"12.03.2023": "12.03.2023",
+	}
+	for in, expect := range cases {
+		if out := formatDueInput(in); out != expect {
+			t.Fatalf("formatDueInput(%q) = %q, want %q", in, out, expect)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- show field labels again when adding or editing a task
- add placeholder and improved formatting for due date input
- calculate modal height based on form content
- test new date formatting helper

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846cb0e31d883309fb88294b80042c8