### PR TITLE
Improve date input handling

### DIFF
--- a/cmd/datefmt.go
+++ b/cmd/datefmt.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+// localeUS returns true if the system locale suggests an US date format.
+func localeUS() bool {
+	lang := os.Getenv("LC_TIME")
+	if lang == "" {
+		lang = os.Getenv("LANG")
+	}
+	lang = strings.ToLower(lang)
+	return strings.Contains(lang, "us")
+}
+
+// dueLayout returns the date layout for the current locale.
+func dueLayout() string {
+	if localeUS() {
+		return "01/02/2006"
+	}
+	return "02.01.2006"
+}
+
+// duePlaceholder returns the placeholder string for due date entry.
+func duePlaceholder() string {
+	if localeUS() {
+		return "mm/dd/yyyy"
+	}
+	return "dd.mm.yyyy"
+}
+
+// isoToLocal converts an ISO date (YYYY-MM-DD) to the locale specific format.
+func isoToLocal(iso string) string {
+	if iso == "" {
+		return ""
+	}
+	t, err := time.Parse("2006-01-02", iso)
+	if err != nil {
+		return ""
+	}
+	return t.Format(dueLayout())
+}
+
+// localToISO converts a locale specific date to ISO format (YYYY-MM-DD).
+func localToISO(local string) (string, error) {
+	if local == "" {
+		return "", nil
+	}
+	t, err := time.Parse(dueLayout(), local)
+	if err != nil {
+		return "", err
+	}
+	return t.Format("2006-01-02"), nil
+}

--- a/cmd/due_test.go
+++ b/cmd/due_test.go
@@ -1,7 +1,10 @@
 package cmd
 
-import "testing"
-import "time"
+import (
+	"os"
+	"testing"
+	"time"
+)
 
 func TestDueSuffix(t *testing.T) {
 	now := time.Date(2025, 6, 10, 10, 0, 0, 0, time.UTC)
@@ -17,6 +20,7 @@ func TestDueSuffix(t *testing.T) {
 }
 
 func TestFormatDueInput(t *testing.T) {
+	os.Unsetenv("LC_TIME")
 	cases := map[string]string{
 		"1":          "1",
 		"12":         "12.",
@@ -25,6 +29,26 @@ func TestFormatDueInput(t *testing.T) {
 		"120320":     "12.03.20",
 		"12032023":   "12.03.2023",
 		"12.03.2023": "12.03.2023",
+	}
+	for in, expect := range cases {
+		if out := formatDueInput(in); out != expect {
+			t.Fatalf("formatDueInput(%q) = %q, want %q", in, out, expect)
+		}
+	}
+}
+
+func TestFormatDueInputUS(t *testing.T) {
+	os.Setenv("LC_TIME", "en_US")
+	defer os.Unsetenv("LC_TIME")
+
+	cases := map[string]string{
+		"1":          "1",
+		"12":         "12/",
+		"120":        "12/0",
+		"1203":       "12/03",
+		"120320":     "12/03/20",
+		"12032023":   "12/03/2023",
+		"12/03/2023": "12/03/2023",
 	}
 	for in, expect := range cases {
 		if out := formatDueInput(in); out != expect {

--- a/cmd/ui_lanes.go
+++ b/cmd/ui_lanes.go
@@ -165,6 +165,10 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 
 	l.add.SetDoneFunc(func(text string, secondary string, success bool) {
 		if success {
+			if !l.add.DueValid() {
+				l.showError("add", "Invalid due date")
+				return
+			}
 			item := l.lanes[l.active].GetCurrentItem()
 			if len(text) == 0 {
 				text = "(empty)"
@@ -192,6 +196,10 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 
 	l.edit.SetDoneFunc(func(text string, secondary string, success bool) {
 		if success {
+			if !l.edit.DueValid() {
+				l.showError("edit", "Invalid due date")
+				return
+			}
 			item := l.lanes[l.active].GetCurrentItem()
 			itemVal := l.currentItem()
 			itemVal.Title = text
@@ -211,6 +219,18 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 	l.pages.AddPage("edit", l.edit, false, false)
 
 	return l
+}
+
+func (l *Lanes) showError(pageReturn, message string) {
+	modal := tview.NewModal().
+		SetText(message).
+		AddButtons([]string{"OK"}).
+		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+			l.pages.HidePage("error")
+			l.pages.ShowPage(pageReturn)
+			l.setActive()
+		})
+	l.pages.AddPage("error", modal, false, true)
 }
 
 func (l *Lanes) CmdLanesCmds() {

--- a/cmd/ui_notes.go
+++ b/cmd/ui_notes.go
@@ -12,17 +12,6 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
-func isoToLocal(iso string) string {
-	if iso == "" {
-		return ""
-	}
-	t, err := time.Parse("2006-01-02", iso)
-	if err != nil {
-		return ""
-	}
-	return t.Format("02.01.2006")
-}
-
 func (l *Lanes) CmdAddTask() {
 	l.saveActive()
 	now := time.Now()


### PR DESCRIPTION
## Summary
- add locale-aware date helpers
- update inputmodal to use locale date formats and validations
- rename details input
- validate due date before closing dialogs and show error
- expand date input tests for US locale

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846cf2b1fe083309265f417cf6d9fca