### PR TITLE
Improve dialog usability

### DIFF
--- a/cmd/due_test.go
+++ b/cmd/due_test.go
@@ -56,3 +56,24 @@ func TestFormatDueInputUS(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveLastDueDigit(t *testing.T) {
+	os.Unsetenv("LC_TIME")
+	cases := map[string]string{
+		"":           "",
+		"1":          "",
+		"12.":        "1",
+		"12.03.2023": "12.03.202",
+	}
+	for in, expect := range cases {
+		if out := removeLastDueDigit(in); out != expect {
+			t.Fatalf("removeLastDueDigit(%q) = %q, want %q", in, out, expect)
+		}
+	}
+
+	os.Setenv("LC_TIME", "en_US")
+	defer os.Unsetenv("LC_TIME")
+	if out := removeLastDueDigit("12/03/2023"); out != "12/03/202" {
+		t.Fatalf("removeLastDueDigit US failed: %s", out)
+	}
+}

--- a/cmd/ui_modes.go
+++ b/cmd/ui_modes.go
@@ -66,7 +66,7 @@ func (l *Lanes) CmdSelectModeDialog() {
 		// SetText("Modes allow separation of ToDo lists into categories.\n\nSelect an existing mode, 'Add' a new, or 'Merge/Remove' the current mode (tasks of all lanes are moved to the lanes of another mode or archived)").
 		SetText("Modes allow separation of ToDo lists into categories. Select an existing mode from the list:").
 		// AddButtons(append(modes, "Add", "Merge/Remove", "Cancel")).
-		AddButtons(append(modes, "Add", "Cancel")).
+		AddButtons(append(modes, " Add...", "Cancel")).
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 			l.cmdSelectModeDialogAction(buttonIndex, buttonLabel, lastIndex)
 		})
@@ -108,7 +108,7 @@ func (l *Lanes) cmdRemoveModeAction(buttonIndex int, buttonLabel string, lastInd
 func (l *Lanes) cmdSelectModeDialogAction(buttonIndex int, buttonLabel string, lastIndex int) {
 	if buttonIndex >= 0 {
 		switch buttonLabel {
-		case "Add":
+		case " Add...":
 			l.pages.HidePage("mode")
 			l.pages.ShowPage("addMode")
 			return


### PR DESCRIPTION
## Summary
- rename task input label to "Title:" and grey out OK until text entered
- add backspace handling across date fields
- tweak mode selection dialog button
- test date backspace helper

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846ddd8be70833093a22e8ce7d36556