### PR TITLE
Fix locale format for info dates

### DIFF
--- a/cmd/datefmt.go
+++ b/cmd/datefmt.go
@@ -82,3 +82,22 @@ func localToISO(local string) (string, error) {
 	}
 	return t.Format("2006-01-02"), nil
 }
+
+// dateTimeLayout returns the date and time layout for the current locale.
+// The time format omits seconds and uses 24h style.
+func dateTimeLayout() string {
+	return dueLayout() + " 15:04"
+}
+
+// isoTimeToLocal converts a RFC3339 timestamp to the locale specific date and
+// time format without seconds.
+func isoTimeToLocal(iso string) string {
+	if iso == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, iso)
+	if err != nil {
+		return ""
+	}
+	return t.Local().Format(dateTimeLayout())
+}

--- a/cmd/datefmt_test.go
+++ b/cmd/datefmt_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"os"
+	"testing"
+	"time"
+)
 
 func TestLocaleUSApple(t *testing.T) {
 	cases := map[string]bool{
@@ -15,4 +19,23 @@ func TestLocaleUSApple(t *testing.T) {
 			t.Fatalf("localeUSApple(%q)=%v want %v", in, got, want)
 		}
 	}
+}
+
+func TestIsoTimeToLocal(t *testing.T) {
+	iso := "2025-03-23T14:11:51Z"
+
+	os.Unsetenv("LC_TIME")
+	t1, _ := time.Parse(time.RFC3339, iso)
+	want := t1.Local().Format(dueLayout() + " 15:04")
+	if got := isoTimeToLocal(iso); got != want {
+		t.Fatalf("isoTimeToLocal non-US got %q want %q", got, want)
+	}
+
+	os.Setenv("LC_TIME", "en_US")
+	t2, _ := time.Parse(time.RFC3339, iso)
+	want = t2.Local().Format(dueLayout() + " 15:04")
+	if got := isoTimeToLocal(iso); got != want {
+		t.Fatalf("isoTimeToLocal US got %q want %q", got, want)
+	}
+	os.Unsetenv("LC_TIME")
 }

--- a/cmd/ui_notes.go
+++ b/cmd/ui_notes.go
@@ -18,7 +18,7 @@ func (l *Lanes) CmdAddTask() {
 	l.add.ClearExtras()
 	l.add.SetPriority(2)
 	l.add.SetDue("")
-	l.add.SetValue("", fmt.Sprintf("created: %v", now.Format("2006-01-02")), "")
+	l.add.SetValue("", fmt.Sprintf("created: %v", now.Format(dueLayout())), "")
 	l.pages.ShowPage("add")
 }
 
@@ -28,13 +28,11 @@ func (l *Lanes) CmdEditTask() {
 		l.edit.ClearExtras()
 		l.edit.SetPriority(item.Priority)
 		l.edit.SetDue(isoToLocal(item.Due))
-		createdTime, _ := time.Parse(time.RFC3339, item.Created)
-		updatedTime, _ := time.Parse(time.RFC3339, item.LastUpdate)
-		createdStr := createdTime.Local().Format("2006-01-02 15:04:05")
+		createdStr := isoTimeToLocal(item.Created)
 		var updatedStr string
 		var updatedBy string
 		if item.LastUpdate != item.Created {
-			updatedStr = updatedTime.Local().Format("2006-01-02 15:04:05")
+			updatedStr = isoTimeToLocal(item.LastUpdate)
 			updatedBy = item.UpdatedByName
 		}
 		l.edit.SetInfo(item.UserName, createdStr, updatedBy, updatedStr)


### PR DESCRIPTION
## Summary
- add helper for locale-based date+time formatting
- use helper when populating task info fields
- test RFC3339 time conversion to locale format

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846e2efa5c48330ae96d72ae1bdddd8