### PR TITLE
Use modal wrapper for edit dialog

### DIFF
--- a/cmd/modalwrapper.go
+++ b/cmd/modalwrapper.go
@@ -1,0 +1,16 @@
+package cmd
+
+import "github.com/rivo/tview"
+
+// modal wraps the provided primitive in an overlay centered on the screen.
+// The surrounding boxes make sure that mouse events outside the modal are
+// consumed so that underlying pages cannot receive them.
+func modal(p tview.Primitive) tview.Primitive {
+	return tview.NewFlex().
+		AddItem(tview.NewBox(), 0, 1, false).
+		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(tview.NewBox(), 0, 1, false).
+			AddItem(p, 0, 1, true).
+			AddItem(tview.NewBox(), 0, 1, false), 0, 1, true).
+		AddItem(tview.NewBox(), 0, 1, false)
+}

--- a/cmd/ui_lanes.go
+++ b/cmd/ui_lanes.go
@@ -216,7 +216,7 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 		l.pages.HidePage("edit")
 		l.setActive()
 	})
-	l.pages.AddPage("edit", l.edit, true, false)
+	l.pages.AddPage("edit", modal(l.edit), true, false)
 
 	return l
 }


### PR DESCRIPTION
## Summary
- ensure edit dialog consumes mouse events by wrapping it in a modal

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846f0a8be848330b80878a889053748