### PR TITLE
Add color selection for task titles

### DIFF
--- a/cmd/colorinput.go
+++ b/cmd/colorinput.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// ColorInput is a form item that combines an input field with a color drop-down.
+type ColorInput struct {
+	*tview.Flex
+	input    *tview.InputField
+	dropdown *tview.DropDown
+	colors   []string
+}
+
+// NewColorInput creates a new ColorInput. colors is a slice of color names. The
+// first entry should be "default".
+func NewColorInput(label string, colors []string) *ColorInput {
+	input := tview.NewInputField().SetLabel(label)
+	dd := tview.NewDropDown()
+	dd.SetLabel("")
+	disp := make([]string, len(colors))
+	for i, c := range colors {
+		if i == 0 || c == "" {
+			disp[i] = "default"
+		} else {
+			disp[i] = "[" + c + "]" + c
+		}
+	}
+	dd.SetOptions(disp, nil)
+	flex := tview.NewFlex().SetDirection(tview.FlexColumn)
+	flex.AddItem(input, 0, 4, true)
+	flex.AddItem(dd, 0, 1, false)
+	return &ColorInput{flex, input, dd, colors}
+}
+
+// GetLabel returns the item's label text.
+func (c *ColorInput) GetLabel() string {
+	return c.input.GetLabel()
+}
+
+// SetFormAttributes sets form attributes for both widgets.
+func (c *ColorInput) SetFormAttributes(labelWidth int, labelColor, bgColor, fieldTextColor, fieldBgColor tcell.Color) tview.FormItem {
+	c.input.SetFormAttributes(labelWidth, labelColor, bgColor, fieldTextColor, fieldBgColor)
+	c.dropdown.SetFormAttributes(0, labelColor, bgColor, fieldTextColor, fieldBgColor)
+	return c
+}
+
+// GetFieldWidth returns 0 to use available width.
+func (c *ColorInput) GetFieldWidth() int {
+	return 0
+}
+
+// GetFieldHeight returns the field height.
+func (c *ColorInput) GetFieldHeight() int {
+	return 1
+}
+
+// SetFinishedFunc installs a handler for the input field.
+func (c *ColorInput) SetFinishedFunc(handler func(key tcell.Key)) tview.FormItem {
+	c.input.SetFinishedFunc(handler)
+	return c
+}
+
+// removePrefix returns text without a leading color prefix.
+func removePrefix(text string) string {
+	if strings.HasPrefix(text, "[") {
+		if idx := strings.Index(text, "]"); idx > 0 {
+			return text[idx+1:]
+		}
+	}
+	return text
+}
+
+// applyPrefix adds or replaces the color prefix.
+func applyPrefix(text, color string) string {
+	base := removePrefix(text)
+	if color == "" || color == "default" {
+		return base
+	}
+	return "[" + color + "]" + base
+}
+
+// parsePrefix splits a title into color prefix and the remaining text.
+func parsePrefix(text string) (string, string) {
+	if strings.HasPrefix(text, "[") {
+		if idx := strings.Index(text, "]"); idx > 0 {
+			return strings.ToLower(text[1:idx]), text[idx+1:]
+		}
+	}
+	return "", text
+}

--- a/cmd/colorinput_test.go
+++ b/cmd/colorinput_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import "testing"
+
+func TestParsePrefix(t *testing.T) {
+	color, text := parsePrefix("[blue]hello")
+	if color != "blue" || text != "hello" {
+		t.Fatalf("expected blue/hello got %s/%s", color, text)
+	}
+	color, text = parsePrefix("hello")
+	if color != "" || text != "hello" {
+		t.Fatalf("expected empty/hello got %s/%s", color, text)
+	}
+}
+
+func TestApplyPrefix(t *testing.T) {
+	if out := applyPrefix("hello", "blue"); out != "[blue]hello" {
+		t.Fatalf("applyPrefix failed: %s", out)
+	}
+	if out := applyPrefix("[red]hello", ""); out != "hello" {
+		t.Fatalf("applyPrefix remove failed: %s", out)
+	}
+}

--- a/cmd/ui_notes.go
+++ b/cmd/ui_notes.go
@@ -18,6 +18,7 @@ func (l *Lanes) CmdAddTask() {
 	l.add.ClearExtras()
 	l.add.SetPriority(2)
 	l.add.SetDue("")
+	l.add.SetColor("")
 	l.add.SetValue("", fmt.Sprintf("created: %v", now.Format(dueLayout())), "")
 	l.pages.ShowPage("add")
 }
@@ -36,7 +37,9 @@ func (l *Lanes) CmdEditTask() {
 			updatedBy = item.UpdatedByName
 		}
 		l.edit.SetInfo(item.UserName, createdStr, updatedBy, updatedStr)
-		l.edit.SetValue(item.Title, item.Secondary, isoToLocal(item.Due))
+		color, base := parsePrefix(item.Title)
+		l.edit.SetColor(color)
+		l.edit.SetValue(base, item.Secondary, isoToLocal(item.Due))
 		l.pages.ShowPage("edit")
 	}
 }


### PR DESCRIPTION
## Summary
- support color tag parsing and generation
- add `ColorInput` widget combining input field and color dropdown
- enable color selection in add/edit dialogs
- test color prefix helper functions

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847419292708330833f7457f88b9f1e