### PR TITLE
Ensure dialog focus is modal

### DIFF
--- a/cmd/ui_lanes_test.go
+++ b/cmd/ui_lanes_test.go
@@ -44,3 +44,30 @@ func TestNoSelectionChangeDuringAdd(t *testing.T) {
 		t.Fatalf("selection changed while adding")
 	}
 }
+
+func TestAddTaskFocus(t *testing.T) {
+	c := &ToDoContent{}
+	c.InitializeNew()
+	app := tview.NewApplication()
+	l := NewLanes(c, app, "", t.TempDir())
+
+	l.CmdAddTask()
+
+	if app.GetFocus() != l.add.titleField {
+		t.Fatalf("focus not on add task dialog")
+	}
+}
+
+func TestEditTaskFocus(t *testing.T) {
+	c := &ToDoContent{}
+	c.InitializeNew()
+	c.AddItem(0, 0, "task", "", 2, "")
+	app := tview.NewApplication()
+	l := NewLanes(c, app, "", t.TempDir())
+
+	l.CmdEditTask()
+
+	if app.GetFocus() != l.edit.titleField {
+		t.Fatalf("focus not on edit task dialog")
+	}
+}

--- a/cmd/ui_notes.go
+++ b/cmd/ui_notes.go
@@ -20,6 +20,7 @@ func (l *Lanes) CmdAddTask() {
 	l.add.SetDue("")
 	l.add.SetValue("", fmt.Sprintf("created: %v", now.Format(dueLayout())), "")
 	l.pages.ShowPage("add")
+	l.app.SetFocus(l.add)
 }
 
 func (l *Lanes) CmdEditTask() {
@@ -38,6 +39,7 @@ func (l *Lanes) CmdEditTask() {
 		l.edit.SetInfo(item.UserName, createdStr, updatedBy, updatedStr)
 		l.edit.SetValue(item.Title, item.Secondary, isoToLocal(item.Due))
 		l.pages.ShowPage("edit")
+		l.app.SetFocus(l.edit)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep focus trapped in the Add Task and Edit Task dialogs
- test that opening these dialogs moves the focus to the input field

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684745d7ba64833080b0f25810a0412a