### PR TITLE
Handle task color internally

### DIFF
--- a/cmd/contents.go
+++ b/cmd/contents.go
@@ -24,6 +24,7 @@ type Item struct {
 	Created       string
 	LastUpdate    string
 	Due           string
+	Color         string
 	UserName      string
 	UpdatedByName string
 	Mode          string
@@ -130,7 +131,7 @@ func (c *ToDoContent) ArchiveItem(lane, idx int) error {
 	return nil
 }
 
-func (c *ToDoContent) AddItem(lane, idx int, title string, secondary string, priority int, due string) {
+func (c *ToDoContent) AddItem(lane, idx int, title string, secondary string, priority int, due, color string) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	usr, err := user.Current()
 	userName := ""
@@ -148,6 +149,7 @@ func (c *ToDoContent) AddItem(lane, idx int, title string, secondary string, pri
 		Created:       now,
 		LastUpdate:    now,
 		Due:           due,
+		Color:         color,
 		UserName:      userName,
 		UpdatedByName: userName,
 		Mode:          "",
@@ -179,6 +181,11 @@ func (c *ToDoContent) normalize() {
 				} else {
 					item.LastUpdate = now
 				}
+			}
+			if item.Color == "" {
+				var col string
+				col, item.Title = parsePrefix(item.Title)
+				item.Color = col
 			}
 			if item.UserName == "" {
 				item.UserName = userName

--- a/cmd/contents_test.go
+++ b/cmd/contents_test.go
@@ -20,7 +20,7 @@ func TestInsertNewLane(t *testing.T) {
 func TestMoveItem(t *testing.T) {
 	c := &ToDoContent{}
 	c.InitializeNew()
-	c.AddItem(0, 0, "task", "", 2, "")
+	c.AddItem(0, 0, "task", "", 2, "", "")
 	c.MoveItem(0, 0, 1, 0)
 	if len(c.Items[0]) != 0 {
 		t.Fatalf("item not removed from source")
@@ -46,7 +46,7 @@ func TestRemoveLane(t *testing.T) {
 func TestGetLaneTitle(t *testing.T) {
 	c := &ToDoContent{}
 	c.InitializeNew()
-	c.AddItem(0, 0, "task", "", 2, "")
+	c.AddItem(0, 0, "task", "", 2, "", "")
 	title := c.GetLaneTitle(0)
 	if title != " To Do (1) " {
 		t.Fatalf("unexpected title: %s", title)
@@ -56,7 +56,7 @@ func TestGetLaneTitle(t *testing.T) {
 func TestAddItemPriority(t *testing.T) {
 	c := &ToDoContent{}
 	c.InitializeNew()
-	c.AddItem(0, 0, "p task", "", 3, "")
+	c.AddItem(0, 0, "p task", "", 3, "", "")
 	if c.Items[0][0].Priority != 3 {
 		t.Fatalf("expected priority 3 got %d", c.Items[0][0].Priority)
 	}
@@ -65,7 +65,7 @@ func TestAddItemPriority(t *testing.T) {
 func TestAddItemDue(t *testing.T) {
 	c := &ToDoContent{}
 	c.InitializeNew()
-	c.AddItem(0, 0, "due task", "", 2, "2025-06-10")
+	c.AddItem(0, 0, "due task", "", 2, "2025-06-10", "")
 	if c.Items[0][0].Due != "2025-06-10" {
 		t.Fatalf("expected due 2025-06-10 got %s", c.Items[0][0].Due)
 	}

--- a/cmd/inputmodal.go
+++ b/cmd/inputmodal.go
@@ -182,7 +182,7 @@ func (m *ModalInput) SetValue(text string, secondary string, due string) {
 	if m.showColor {
 		ci := NewColorInput("Title:", m.colors)
 		titleField = ci.input
-		titleField.SetText(applyPrefix(text, m.color))
+		titleField.SetText(text)
 		titleField.SetChangedFunc(func(text string) {
 			if len(text) == 0 {
 				text = "(empty)"
@@ -200,10 +200,6 @@ func (m *ModalInput) SetValue(text string, secondary string, due string) {
 		ci.dropdown.SetCurrentOption(idx)
 		ci.dropdown.SetSelectedFunc(func(option string, index int) {
 			m.color = m.colors[index]
-			base := removePrefix(titleField.GetText())
-			newText := applyPrefix(base, m.color)
-			titleField.SetText(newText)
-			m.main = newText
 		})
 		m.AddFormItem(ci)
 	} else {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -51,6 +51,9 @@ func (l *Lanes) redrawLane(laneIndex, active int) error {
 	now := time.Now()
 	for _, item := range l.content.GetLaneItems(laneIndex) {
 		title := item.Title
+		if item.Color != "" {
+			title = "[" + item.Color + "]" + title
+		}
 		if suffix := dueSuffix(item.Due, now); suffix != "" {
 			title += " " + suffix
 		}

--- a/cmd/ui_lanes.go
+++ b/cmd/ui_lanes.go
@@ -175,7 +175,8 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 			}
 			prio := l.add.GetPriority()
 			due := l.add.GetDueISO()
-			l.content.AddItem(l.active, item, text, secondary, prio, due)
+			color := l.add.GetColor()
+			l.content.AddItem(l.active, item, text, secondary, prio, due, color)
 			l.redrawLane(l.active, item)
 			content.Save()
 		}
@@ -206,6 +207,7 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 			itemVal.Secondary = secondary
 			itemVal.Priority = l.edit.GetPriority()
 			itemVal.Due = l.edit.GetDueISO()
+			itemVal.Color = l.edit.GetColor()
 			itemVal.LastUpdate = time.Now().UTC().Format(time.RFC3339)
 			if usr, err := user.Current(); err == nil {
 				itemVal.UpdatedByName = usr.Username

--- a/cmd/ui_lanes_test.go
+++ b/cmd/ui_lanes_test.go
@@ -9,8 +9,8 @@ import (
 func TestNoSelectionChangeDuringEdit(t *testing.T) {
 	c := &ToDoContent{}
 	c.InitializeNew()
-	c.AddItem(0, 0, "task 1", "", 2, "")
-	c.AddItem(0, 1, "task 2", "", 2, "")
+	c.AddItem(0, 0, "task 1", "", 2, "", "")
+	c.AddItem(0, 1, "task 2", "", 2, "", "")
 	app := tview.NewApplication()
 	l := NewLanes(c, app, "", t.TempDir())
 
@@ -29,8 +29,8 @@ func TestNoSelectionChangeDuringEdit(t *testing.T) {
 func TestNoSelectionChangeDuringAdd(t *testing.T) {
 	c := &ToDoContent{}
 	c.InitializeNew()
-	c.AddItem(0, 0, "task 1", "", 2, "")
-	c.AddItem(0, 1, "task 2", "", 2, "")
+	c.AddItem(0, 0, "task 1", "", 2, "", "")
+	c.AddItem(0, 1, "task 2", "", 2, "", "")
 	app := tview.NewApplication()
 	l := NewLanes(c, app, "", t.TempDir())
 
@@ -61,7 +61,7 @@ func TestAddTaskFocus(t *testing.T) {
 func TestEditTaskFocus(t *testing.T) {
 	c := &ToDoContent{}
 	c.InitializeNew()
-	c.AddItem(0, 0, "task", "", 2, "")
+	c.AddItem(0, 0, "task", "", 2, "", "")
 	app := tview.NewApplication()
 	l := NewLanes(c, app, "", t.TempDir())
 

--- a/cmd/ui_notes.go
+++ b/cmd/ui_notes.go
@@ -38,9 +38,8 @@ func (l *Lanes) CmdEditTask() {
 			updatedBy = item.UpdatedByName
 		}
 		l.edit.SetInfo(item.UserName, createdStr, updatedBy, updatedStr)
-		color, base := parsePrefix(item.Title)
-		l.edit.SetColor(color)
-		l.edit.SetValue(base, item.Secondary, isoToLocal(item.Due))
+		l.edit.SetColor(item.Color)
+		l.edit.SetValue(item.Title, item.Secondary, isoToLocal(item.Due))
 		l.pages.ShowPage("edit")
 		l.app.SetFocus(l.edit)
 	}


### PR DESCRIPTION
## Summary
- add a `Color` field to `Item`
- include color when adding items and during edit
- keep user dialogs free of color prefixes
- draw items with color prefix in lanes
- migrate existing data by extracting color prefix on load

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68474a09ae30833093151e1e0970c164