### PR TITLE
Add modal input capture

### DIFF
--- a/cmd/ui_lanes.go
+++ b/cmd/ui_lanes.go
@@ -41,7 +41,13 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 	l := &Lanes{"", 0, todoDirModes, mode, content, make([]*tview.List, content.GetNumLanes()), 0, 0, false, tview.NewPages(), app, false,
 		NewModalInput("Add Task"),
 		NewModalInput("Edit Task"),
-		NewModalInputMode("Add Mode", todoDirModes), nil}
+		NewModalInputMode("Add Mode", todoDirModes), nil,
+		false, nil, nil, nil}
+
+	l.origInputCapture = app.GetInputCapture()
+	app.SetInputCapture(l.appInputCapture)
+	l.origMouseCapture = app.GetMouseCapture()
+	app.SetMouseCapture(l.appMouseCapture)
 	flex := tview.NewFlex()
 	for i := 0; i < l.content.GetNumLanes(); i++ {
 		l.lanes[i] = tview.NewList()
@@ -180,8 +186,7 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 			l.redrawLane(l.active, item)
 			content.Save()
 		}
-		l.pages.HidePage("add")
-		l.setActive()
+		l.hideDialog("add")
 	})
 	l.pages.AddPage("add", modal(l.add, 0, 0), true, false)
 
@@ -215,8 +220,7 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 			l.redrawLane(l.active, item)
 			l.content.Save()
 		}
-		l.pages.HidePage("edit")
-		l.setActive()
+		l.hideDialog("edit")
 	})
 	l.pages.AddPage("edit", modal(l.edit, 0, 0), false, false)
 

--- a/cmd/ui_notes.go
+++ b/cmd/ui_notes.go
@@ -20,8 +20,7 @@ func (l *Lanes) CmdAddTask() {
 	l.add.SetDue("")
 	l.add.SetColor("")
 	l.add.SetValue("", fmt.Sprintf("created: %v", now.Format(dueLayout())), "")
-	l.pages.ShowPage("add")
-	l.app.SetFocus(l.add)
+	l.showDialog("add", l.add)
 }
 
 func (l *Lanes) CmdEditTask() {
@@ -40,8 +39,7 @@ func (l *Lanes) CmdEditTask() {
 		l.edit.SetInfo(item.UserName, createdStr, updatedBy, updatedStr)
 		l.edit.SetColor(item.Color)
 		l.edit.SetValue(item.Title, item.Secondary, isoToLocal(item.Due))
-		l.pages.ShowPage("edit")
-		l.app.SetFocus(l.edit)
+		l.showDialog("edit", l.edit)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add dialog flag and capture handlers
- hook up modal dialog show/hide to input & mouse capture
- enforce modal behavior in CmdAddTask/CmdEditTask
- test that captures block events when a dialog is open

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68474f7d556883309de6bcd46444daf4