### PR TITLE
Fix edit dialog interactions

### DIFF
--- a/cmd/colorinput.go
+++ b/cmd/colorinput.go
@@ -61,7 +61,25 @@ func (c *ColorInput) GetFieldHeight() int {
 // SetFinishedFunc installs a handler for the input field.
 func (c *ColorInput) SetFinishedFunc(handler func(key tcell.Key)) tview.FormItem {
 	c.input.SetFinishedFunc(handler)
+	c.dropdown.SetDoneFunc(handler)
 	return c
+}
+
+// InputHandler handles tab navigation between input field and dropdown.
+func (c *ColorInput) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	return c.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+		if c.input.HasFocus() && event.Key() == tcell.KeyTab {
+			setFocus(c.dropdown)
+			return
+		}
+		if c.dropdown.HasFocus() && event.Key() == tcell.KeyBacktab {
+			setFocus(c.input)
+			return
+		}
+		if handler := c.Flex.InputHandler(); handler != nil {
+			handler(event, setFocus)
+		}
+	})
 }
 
 // removePrefix returns text without a leading color prefix.

--- a/cmd/colorinput_test.go
+++ b/cmd/colorinput_test.go
@@ -1,6 +1,11 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
 
 func TestParsePrefix(t *testing.T) {
 	color, text := parsePrefix("[blue]hello")
@@ -19,5 +24,35 @@ func TestApplyPrefix(t *testing.T) {
 	}
 	if out := applyPrefix("[red]hello", ""); out != "hello" {
 		t.Fatalf("applyPrefix remove failed: %s", out)
+	}
+}
+
+func TestColorInputTabSwitch(t *testing.T) {
+	ci := NewColorInput("Title:", []string{"default", "blue"})
+	focused := tview.Primitive(nil)
+	setFocus := func(p tview.Primitive) { focused = p; p.Focus(func(p tview.Primitive) {}) }
+
+	ci.Focus(setFocus)
+	if focused != ci.input {
+		t.Fatalf("initial focus not on input")
+	}
+	ci.InputHandler()(tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone), setFocus)
+	if focused != ci.dropdown {
+		t.Fatalf("tab did not move focus to dropdown")
+	}
+	ci.InputHandler()(tcell.NewEventKey(tcell.KeyBacktab, 0, tcell.ModNone), setFocus)
+	if focused != ci.input {
+		t.Fatalf("backtab did not return focus to input")
+	}
+}
+
+func TestColorInputFinishedFunc(t *testing.T) {
+	ci := NewColorInput("Title:", []string{"default", "blue"})
+	called := false
+	ci.SetFinishedFunc(func(k tcell.Key) { called = true })
+
+	ci.dropdown.InputHandler()(tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone), func(p tview.Primitive) {})
+	if !called {
+		t.Fatalf("finished func not called for dropdown")
 	}
 }

--- a/cmd/ui_lanes.go
+++ b/cmd/ui_lanes.go
@@ -222,7 +222,7 @@ func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes s
 		}
 		l.hideDialog("edit")
 	})
-	l.pages.AddPage("edit", modal(l.edit, 0, 0), false, false)
+	l.pages.AddPage("edit", modal(l.edit, 0, 0), true, false)
 
 	return l
 }


### PR DESCRIPTION
## Summary
- ensure edit dialog resizes like the add dialog
- allow tab navigation between title field and color dropdown
- test color input focus handling

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847536bbe988330ad20a81ff64906a4