### PR TITLE
Add task sorting feature

### DIFF
--- a/cmd/contents_test.go
+++ b/cmd/contents_test.go
@@ -100,3 +100,16 @@ func TestSplit(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeSortModes(t *testing.T) {
+	c := &ToDoContent{Titles: []string{"A", "B"}, Items: make([][]Item, 2)}
+	c.normalize()
+	if len(c.SortModes) != 2 {
+		t.Fatalf("expected 2 sort modes got %d", len(c.SortModes))
+	}
+	for i, m := range c.SortModes {
+		if m != "" {
+			t.Fatalf("sort mode %d should be empty", i)
+		}
+	}
+}

--- a/cmd/inputmodal.go
+++ b/cmd/inputmodal.go
@@ -32,6 +32,10 @@ type ModalInput struct {
 	done         func(string, string, bool)
 }
 
+func (m *ModalInput) GetFrame() *tview.Frame {
+	return m.frame
+}
+
 func (m *ModalInput) updateOKButton() {
 	if m.okButton == nil {
 		return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,6 +124,10 @@ func getStatusBar(lanes *Lanes, mode string) *tview.Flex {
 	bLanesCommands.SetBackgroundColor(tcell.ColorLightGray)
 	bLanesCommands.SetSelectedFunc(lanes.CmdLanesCmds)
 
+	bSort := tview.NewButton("[red::-]F8 [black::-]Sort")
+	bSort.SetBackgroundColor(tcell.ColorLightGray)
+	bSort.SetSelectedFunc(lanes.CmdSortDialog)
+
 	bExit := tview.NewButton("[brown::-]F10 [black::-]Exit")
 	bExit.SetBackgroundColor(tcell.ColorLightGray)
 	bExit.SetSelectedFunc(lanes.CmdExit)
@@ -144,6 +148,7 @@ func getStatusBar(lanes *Lanes, mode string) *tview.Flex {
 		AddItem(bArchiveToDo, 13, 1, false).
 		AddItem(bSelectToDo, 10, 1, false).
 		AddItem(bLanesCommands, 9, 1, false).
+		AddItem(bSort, 9, 1, false).
 		AddItem(bExit, 10, 1, false).
 		AddItem(bMode, 2+len(mode), 1, false).
 		AddItem(bMoveHelp, 38, 1, false)

--- a/cmd/sort.go
+++ b/cmd/sort.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"sort"
+	"time"
+)
+
+const (
+	SortNone     = ""
+	SortColor    = "color"
+	SortDue      = "due"
+	SortCreated  = "created"
+	SortModified = "modified"
+	SortPriority = "priority"
+)
+
+func priorityMark(p int) string {
+	switch p {
+	case 1:
+		return "↑"
+	case 3:
+		return "↓"
+	case 4:
+		return "⌛"
+	default:
+		return ""
+	}
+}
+
+func sortItems(items []Item, mode string) {
+	switch mode {
+	case SortColor:
+		sort.SliceStable(items, func(i, j int) bool {
+			return items[i].Color < items[j].Color
+		})
+	case SortDue:
+		sort.SliceStable(items, func(i, j int) bool {
+			ti := parseDue(items[i].Due)
+			tj := parseDue(items[j].Due)
+			return ti.Before(tj)
+		})
+	case SortCreated:
+		sort.SliceStable(items, func(i, j int) bool {
+			ti := parseTime(items[i].Created)
+			tj := parseTime(items[j].Created)
+			return ti.Before(tj)
+		})
+	case SortModified:
+		sort.SliceStable(items, func(i, j int) bool {
+			ti := parseTime(items[i].LastUpdate)
+			if ti.IsZero() {
+				ti = parseTime(items[i].Created)
+			}
+			tj := parseTime(items[j].LastUpdate)
+			if tj.IsZero() {
+				tj = parseTime(items[j].Created)
+			}
+			return ti.Before(tj)
+		})
+	case SortPriority:
+		sort.SliceStable(items, func(i, j int) bool {
+			return items[i].Priority < items[j].Priority
+		})
+	}
+}
+
+func parseDue(d string) time.Time {
+	if t, err := time.Parse("2006-01-02", d); err == nil {
+		return t
+	}
+	return time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func parseTime(tstr string) time.Time {
+	if t, err := time.Parse(time.RFC3339, tstr); err == nil {
+		return t
+	}
+	return time.Time{}
+}

--- a/cmd/sort_dialog.go
+++ b/cmd/sort_dialog.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// SortModal is a simple modal with a dropdown for sort mode
+type SortModal struct {
+	*tview.Form
+	DialogHeight int
+	frame        *tview.Frame
+	optionIndex  int
+	options      []string
+	done         func(string, bool)
+}
+
+func (m *SortModal) GetFrame() *tview.Frame {
+	return m.frame
+}
+
+func NewSortModal(title, lane string, current string) *SortModal {
+	form := tview.NewForm()
+	m := &SortModal{Form: form, DialogHeight: 7, frame: tview.NewFrame(form), optionIndex: 0,
+		options: []string{"", SortColor, SortDue, SortCreated, SortModified, SortPriority}, done: nil}
+
+	labels := []string{"default", "color", "due", "created", "modified", "priority"}
+	idx := 0
+	for i, v := range m.options {
+		if v == current {
+			idx = i
+			break
+		}
+	}
+	m.optionIndex = idx
+	form.AddDropDown("Sort:", labels, idx, func(option string, index int) {
+		m.optionIndex = index
+	})
+	m.frame.AddText(fmt.Sprintf("Sort tasks in lane '%s'", lane), false, 0, tcell.ColorDarkGray)
+	m.SetButtonsAlign(tview.AlignCenter).
+		SetButtonBackgroundColor(tview.Styles.PrimitiveBackgroundColor).
+		SetButtonTextColor(tview.Styles.PrimaryTextColor).
+		SetBackgroundColor(tview.Styles.ContrastBackgroundColor).
+		SetBorderPadding(0, 0, 0, 0)
+
+	m.AddButton("OK", func() {
+		if m.done != nil {
+			m.done(m.options[m.optionIndex], true)
+		}
+	})
+	m.AddButton("Cancel", func() {
+		if m.done != nil {
+			m.done("", false)
+		}
+	})
+
+	m.frame.SetTitle(fmt.Sprintf(" %v ", title))
+	m.frame.SetBorders(0, 0, 1, 0, 0, 0).
+		SetBorder(true).
+		SetBackgroundColor(tview.Styles.ContrastBackgroundColor).
+		SetBorderPadding(1, 1, 1, 1)
+
+	return m
+}
+
+func (m *SortModal) SetDoneFunc(handler func(string, bool)) {
+	m.done = handler
+}

--- a/cmd/sort_test.go
+++ b/cmd/sort_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "testing"
+
+func TestPriorityMark(t *testing.T) {
+	if m := priorityMark(1); m == "" {
+		t.Fatalf("high priority mark empty")
+	}
+	if m := priorityMark(2); m != "" {
+		t.Fatalf("default priority should be empty")
+	}
+}
+
+func TestSortByDue(t *testing.T) {
+	items := []Item{
+		{Title: "t1", Due: "2025-06-10"},
+		{Title: "t2", Due: ""},
+		{Title: "t3", Due: "2025-01-01"},
+	}
+	sortItems(items, SortDue)
+	if items[0].Title != "t3" || items[1].Title != "t1" || items[2].Title != "t2" {
+		t.Fatalf("due sort failed: %#v", items)
+	}
+}

--- a/cmd/ui_keys.go
+++ b/cmd/ui_keys.go
@@ -7,11 +7,14 @@ func (l *Lanes) HotKeyHandler(event *tcell.EventKey) *tcell.EventKey {
 	case tcell.KeyF10:
 		l.CmdExit()
 		return nil
-	// case tcell.KeyF9:
-	// 	l.CmdSelectMode()
-	// 	return nil
+		// case tcell.KeyF9:
+		// 	l.CmdSelectMode()
+		// 	return nil
 	case tcell.KeyF7:
 		l.CmdLanesCmds()
+		return nil
+	case tcell.KeyF8:
+		l.CmdSortDialog()
 		return nil
 	case tcell.KeyF6:
 		l.CmdSelectNote()

--- a/cmd/ui_lanes.go
+++ b/cmd/ui_lanes.go
@@ -38,11 +38,28 @@ func (l *Lanes) RedrawAllLanes() {
 }
 
 func NewLanes(content *ToDoContent, app *tview.Application, mode, todoDirModes string) *Lanes {
-	l := &Lanes{"", 0, todoDirModes, mode, content, make([]*tview.List, content.GetNumLanes()), 0, 0, false, tview.NewPages(), app, false,
-		NewModalInput("Add Task"),
-		NewModalInput("Edit Task"),
-		NewModalInputMode("Add Mode", todoDirModes), nil,
-		false, nil, nil, nil}
+	l := &Lanes{
+		nextMode:         "",
+		nextLaneFocus:    0,
+		todoDirModes:     todoDirModes,
+		mode:             mode,
+		content:          content,
+		lanes:            make([]*tview.List, content.GetNumLanes()),
+		active:           0,
+		lastActive:       0,
+		lastActiveSaved:  false,
+		pages:            tview.NewPages(),
+		app:              app,
+		inselect:         false,
+		add:              NewModalInput("Add Task"),
+		edit:             NewModalInput("Edit Task"),
+		addMode:          NewModalInputMode("Add Mode", todoDirModes),
+		bMoveHelp:        nil,
+		dialogActive:     false,
+		activeDialog:     nil,
+		origInputCapture: nil,
+		origMouseCapture: nil,
+	}
 
 	l.origInputCapture = app.GetInputCapture()
 	app.SetInputCapture(l.appInputCapture)

--- a/cmd/ui_sort.go
+++ b/cmd/ui_sort.go
@@ -1,0 +1,19 @@
+package cmd
+
+func (l *Lanes) CmdSortDialog() {
+	l.saveActive()
+	laneTitle := l.GetActiveLaneName()
+	current := l.content.SortModes[l.active]
+	dlg := NewSortModal(" Sort Tasks ", laneTitle, current)
+	dlg.SetDoneFunc(func(mode string, ok bool) {
+		l.pages.HidePage("sort")
+		l.setActive()
+		if ok {
+			l.content.SetLaneSort(l.active, mode)
+			l.redrawLane(l.active, l.lanes[l.active].GetCurrentItem())
+			l.content.Save()
+		}
+	})
+	l.pages.AddPage("sort", modal(dlg, 0, 0), false, true)
+	l.showDialog("sort", dlg)
+}


### PR DESCRIPTION
## Summary
- add support for lane sort modes and save them in JSON
- show priority indicators beside tasks
- provide `Sort` command (F8) with dropdown dialog
- implement various sort modes and tests
- ensure legacy JSON files without sort info load in manual mode

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_684758c4b2fc8330ac67129e2ba1199f