### PR TITLE
Fix Sort Dialog

### DIFF
--- a/cmd/sort_dialog.go
+++ b/cmd/sort_dialog.go
@@ -26,7 +26,13 @@ func NewSortModal(title, lane string, current string) *SortModal {
 	m := &SortModal{Form: form, DialogHeight: 7, frame: tview.NewFrame(form), optionIndex: 0,
 		options: []string{"", SortColor, SortDue, SortCreated, SortModified, SortPriority}, done: nil}
 
-	labels := []string{"default", "color", "due", "created", "modified", "priority"}
+	form.SetCancelFunc(func() {
+		if m.done != nil {
+			m.done("", false)
+		}
+	})
+
+	labels := []string{"manual", "color", "due", "created", "modified", "priority"}
 	idx := 0
 	for i, v := range m.options {
 		if v == current {
@@ -67,4 +73,63 @@ func NewSortModal(title, lane string, current string) *SortModal {
 
 func (m *SortModal) SetDoneFunc(handler func(string, bool)) {
 	m.done = handler
+}
+
+// Draw draws this modal with a surrounding frame.
+func (m *SortModal) Draw(screen tcell.Screen) {
+	// Determine width similar to ModalInput.
+	buttonsWidth := 30
+	screenWidth, screenHeight := screen.Size()
+	width := screenWidth / 3
+	if width < buttonsWidth {
+		width = buttonsWidth
+	}
+	height := m.DialogHeight
+	width += 4
+	x := (screenWidth - width) / 2
+	y := (screenHeight - height) / 2
+	m.SetRect(x, y, width, height)
+
+	// Draw the frame.
+	m.frame.SetRect(x, y, width, height)
+	m.frame.Draw(screen)
+}
+
+// Focus delegates focus to the embedded form.
+func (m *SortModal) Focus(delegate func(p tview.Primitive)) {
+	delegate(m.Form)
+}
+
+// HasFocus returns whether the form has focus.
+func (m *SortModal) HasFocus() bool {
+	return m.Form.HasFocus()
+}
+
+// SetFocus passes the focus index to the embedded form.
+func (m *SortModal) SetFocus(index int) *SortModal {
+	m.Form.SetFocus(index)
+	return m
+}
+
+// MouseHandler forwards mouse events to the form and captures clicks inside the dialog.
+func (m *SortModal) MouseHandler() func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (consumed bool, capture tview.Primitive) {
+	return m.WrapMouseHandler(func(action tview.MouseAction, event *tcell.EventMouse, setFocus func(p tview.Primitive)) (consumed bool, capture tview.Primitive) {
+		consumed, capture = m.Form.MouseHandler()(action, event, setFocus)
+		if !consumed && action == tview.MouseLeftDown && m.InRect(event.Position()) {
+			setFocus(m)
+			consumed = true
+		}
+		return
+	})
+}
+
+// InputHandler returns the handler for this primitive.
+func (m *SortModal) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+	return m.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+		if m.frame.HasFocus() {
+			if handler := m.frame.InputHandler(); handler != nil {
+				handler(event, setFocus)
+			}
+		}
+	})
 }

--- a/cmd/sort_dialog_test.go
+++ b/cmd/sort_dialog_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"testing"
+)
+
+func TestNewSortModalManualSelected(t *testing.T) {
+	dlg := NewSortModal("Sort", "lane", "")
+	item := dlg.GetFormItem(0).(*tview.DropDown)
+	_, text := item.GetCurrentOption()
+	if text != "manual" {
+		t.Fatalf("expected initial option 'manual', got '%s'", text)
+	}
+	if dlg.GetButtonIndex("Cancel") == -1 {
+		t.Fatalf("cancel button missing")
+	}
+}
+
+func TestSortModalDrawSetsFrame(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatalf("screen init failed: %v", err)
+	}
+	dlg := NewSortModal("Sort", "lane", "")
+	dlg.Draw(screen)
+	_, _, w, h := dlg.frame.GetRect()
+	if w == 0 || h == 0 {
+		t.Fatalf("frame rect not set by Draw")
+	}
+}


### PR DESCRIPTION
## Summary
- fix sort dialog so it's centered in a frame
- make manual sort the default option and support cancel
- add regression test for the sort modal

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68475d695b38833086e7239d339116da