### PR TITLE
Refactor project layout

### DIFF
--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"runtime"
 	"testing"
+
+	"github.com/cklukas/todo/internal/util"
 )
 
 func TestIsReleaseNewer(t *testing.T) {
@@ -69,15 +71,15 @@ func TestFileWritable(t *testing.T) {
 	}
 	tmp.Close()
 	defer os.Remove(tmp.Name())
-	if !fileWritable(tmp.Name()) {
+	if !util.FileWritable(tmp.Name()) {
 		t.Errorf("expected file to be writable")
 	}
 	os.Chmod(tmp.Name(), 0444)
-	if fileWritable(tmp.Name()) {
+	if util.FileWritable(tmp.Name()) {
 		t.Errorf("expected file to be non writable")
 	}
 	os.Chmod(tmp.Name(), 0666)
-	if !fileWritable(tmp.Name()) {
+	if !util.FileWritable(tmp.Name()) {
 		t.Errorf("expected file to be writable with world permissions")
 	}
 }
@@ -89,9 +91,9 @@ func TestLatestReleaseInfo(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	oldURL := latestReleaseURL
-	latestReleaseURL = srv.URL
-	defer func() { latestReleaseURL = oldURL }()
+	oldURL := util.LatestReleaseURL
+	util.LatestReleaseURL = srv.URL
+	defer func() { util.LatestReleaseURL = oldURL }()
 
 	tag, newer, err := latestReleaseInfo("1.0.0")
 	if err != nil {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -1,4 +1,4 @@
-package cmd
+package config
 
 import (
 	"encoding/json"
@@ -8,7 +8,7 @@ import (
 
 // loadLastModeFromSettings loads the last UI selected mode from
 // $HOME/.todo/settings.json. It returns the mode or an error.
-func loadLastModeFromSettings(home string) (string, error) {
+func LoadLastModeFromSettings(home string) (string, error) {
 	fname := path.Join(home, ".todo", "settings.json")
 	data, err := os.ReadFile(fname)
 	if err != nil {
@@ -28,7 +28,7 @@ func loadLastModeFromSettings(home string) (string, error) {
 
 // saveLastModeToSettings writes the provided mode to
 // $HOME/.todo/settings.json.
-func saveLastModeToSettings(home, mode string) error {
+func SaveLastModeToSettings(home, mode string) error {
 	dir := path.Join(home, ".todo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return err

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -1,4 +1,4 @@
-package cmd
+package config
 
 import (
 	"os"
@@ -10,11 +10,11 @@ func TestSaveLoadLastMode(t *testing.T) {
 	dir := t.TempDir()
 
 	mode := "work"
-	if err := saveLastModeToSettings(dir, mode); err != nil {
+	if err := SaveLastModeToSettings(dir, mode); err != nil {
 		t.Fatalf("save failed: %v", err)
 	}
 
-	got, err := loadLastModeFromSettings(dir)
+	got, err := LoadLastModeFromSettings(dir)
 	if err != nil {
 		t.Fatalf("load failed: %v", err)
 	}

--- a/internal/model/contents.go
+++ b/internal/model/contents.go
@@ -1,4 +1,4 @@
-package cmd
+package model
 
 import (
 	"encoding/json"
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cklukas/todo/internal/util"
 	"github.com/flytam/filenamify"
 	"github.com/google/uuid"
 )
@@ -38,6 +39,14 @@ type ToDoContent struct {
 	archiveFolder  string     `json:"-"`
 	backupFolder   string     `json:"-"`
 	readWriteMutex sync.Mutex `json:"-"`
+}
+
+func (c *ToDoContent) Lock() {
+	c.readWriteMutex.Lock()
+}
+
+func (c *ToDoContent) Unlock() {
+	c.readWriteMutex.Unlock()
 }
 
 func (c *ToDoContent) InitializeNew() {
@@ -206,7 +215,7 @@ func (c *ToDoContent) normalize() {
 			}
 			if item.Color == "" {
 				var col string
-				col, item.Title = parsePrefix(item.Title)
+				col, item.Title = util.ParsePrefix(item.Title)
 				item.Color = col
 			}
 			if item.UserName == "" {

--- a/internal/model/contents_test.go
+++ b/internal/model/contents_test.go
@@ -1,6 +1,10 @@
-package cmd
+package model
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/cklukas/todo/internal/util"
+)
 
 func TestInsertNewLane(t *testing.T) {
 	c := &ToDoContent{}
@@ -79,14 +83,14 @@ func TestNormPos(t *testing.T) {
 		{6, 5, 1},
 	}
 	for _, tc := range tests {
-		if got := normPos(tc.pos, tc.length); got != tc.exp {
+		if got := util.NormPos(tc.pos, tc.length); got != tc.exp {
 			t.Errorf("normPos(%d,%d)=%d expected %d", tc.pos, tc.length, got, tc.exp)
 		}
 	}
 }
 
 func TestSplit(t *testing.T) {
-	words, err := Split("one 'two three' four")
+	words, err := util.Split("one 'two three' four")
 	if err != nil {
 		t.Fatalf("Split returned error: %v", err)
 	}

--- a/internal/model/sort.go
+++ b/internal/model/sort.go
@@ -1,4 +1,4 @@
-package cmd
+package model
 
 import (
 	"sort"
@@ -14,7 +14,7 @@ const (
 	SortPriority = "priority"
 )
 
-func priorityMark(p int) string {
+func PriorityMark(p int) string {
 	switch p {
 	case 1:
 		return "↑"

--- a/internal/model/sort_test.go
+++ b/internal/model/sort_test.go
@@ -1,12 +1,12 @@
-package cmd
+package model
 
 import "testing"
 
 func TestPriorityMark(t *testing.T) {
-	if m := priorityMark(1); m == "" {
+	if m := PriorityMark(1); m == "" {
 		t.Fatalf("high priority mark empty")
 	}
-	if m := priorityMark(2); m != "" {
+	if m := PriorityMark(2); m != "" {
 		t.Fatalf("default priority should be empty")
 	}
 }

--- a/internal/ui/colorinput.go
+++ b/internal/ui/colorinput.go
@@ -1,8 +1,6 @@
-package cmd
+package ui
 
 import (
-	"strings"
-
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -80,33 +78,4 @@ func (c *ColorInput) InputHandler() func(event *tcell.EventKey, setFocus func(p 
 			handler(event, setFocus)
 		}
 	})
-}
-
-// removePrefix returns text without a leading color prefix.
-func removePrefix(text string) string {
-	if strings.HasPrefix(text, "[") {
-		if idx := strings.Index(text, "]"); idx > 0 {
-			return text[idx+1:]
-		}
-	}
-	return text
-}
-
-// applyPrefix adds or replaces the color prefix.
-func applyPrefix(text, color string) string {
-	base := removePrefix(text)
-	if color == "" || color == "default" {
-		return base
-	}
-	return "[" + color + "]" + base
-}
-
-// parsePrefix splits a title into color prefix and the remaining text.
-func parsePrefix(text string) (string, string) {
-	if strings.HasPrefix(text, "[") {
-		if idx := strings.Index(text, "]"); idx > 0 {
-			return strings.ToLower(text[1:idx]), text[idx+1:]
-		}
-	}
-	return "", text
 }

--- a/internal/ui/colorinput_test.go
+++ b/internal/ui/colorinput_test.go
@@ -1,28 +1,29 @@
-package cmd
+package ui
 
 import (
 	"testing"
 
+	"github.com/cklukas/todo/internal/util"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
 func TestParsePrefix(t *testing.T) {
-	color, text := parsePrefix("[blue]hello")
+	color, text := util.ParsePrefix("[blue]hello")
 	if color != "blue" || text != "hello" {
 		t.Fatalf("expected blue/hello got %s/%s", color, text)
 	}
-	color, text = parsePrefix("hello")
+	color, text = util.ParsePrefix("hello")
 	if color != "" || text != "hello" {
 		t.Fatalf("expected empty/hello got %s/%s", color, text)
 	}
 }
 
 func TestApplyPrefix(t *testing.T) {
-	if out := applyPrefix("hello", "blue"); out != "[blue]hello" {
+	if out := util.ApplyPrefix("hello", "blue"); out != "[blue]hello" {
 		t.Fatalf("applyPrefix failed: %s", out)
 	}
-	if out := applyPrefix("[red]hello", ""); out != "hello" {
+	if out := util.ApplyPrefix("[red]hello", ""); out != "hello" {
 		t.Fatalf("applyPrefix remove failed: %s", out)
 	}
 }

--- a/internal/ui/datefmt.go
+++ b/internal/ui/datefmt.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 import (
 	"os"

--- a/internal/ui/datefmt_test.go
+++ b/internal/ui/datefmt_test.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 import (
 	"os"

--- a/internal/ui/due_test.go
+++ b/internal/ui/due_test.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 import (
 	"os"

--- a/internal/ui/inputmodal.go
+++ b/internal/ui/inputmodal.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 import (
 	"fmt"

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 import "github.com/rivo/tview"
 

--- a/internal/ui/sort_dialog.go
+++ b/internal/ui/sort_dialog.go
@@ -1,10 +1,12 @@
-package cmd
+package ui
 
 import (
 	"fmt"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+
+	"github.com/cklukas/todo/internal/model"
 )
 
 // SortModal is a simple modal with a dropdown for sort mode
@@ -24,7 +26,7 @@ func (m *SortModal) GetFrame() *tview.Frame {
 func NewSortModal(title, lane string, current string) *SortModal {
 	form := tview.NewForm()
 	m := &SortModal{Form: form, DialogHeight: 7, frame: tview.NewFrame(form), optionIndex: 0,
-		options: []string{"", SortColor, SortDue, SortCreated, SortModified, SortPriority}, done: nil}
+		options: []string{"", model.SortColor, model.SortDue, model.SortCreated, model.SortModified, model.SortPriority}, done: nil}
 
 	form.SetCancelFunc(func() {
 		if m.done != nil {

--- a/internal/ui/sort_dialog_test.go
+++ b/internal/ui/sort_dialog_test.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 import (
 	"github.com/gdamore/tcell/v2"

--- a/internal/ui/ui_keys.go
+++ b/internal/ui/ui_keys.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 import "github.com/gdamore/tcell/v2"
 

--- a/internal/ui/ui_lanes_test.go
+++ b/internal/ui/ui_lanes_test.go
@@ -1,18 +1,20 @@
-package cmd
+package ui
 
 import (
+	"testing"
+
+	"github.com/cklukas/todo/internal/model"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
-	"testing"
 )
 
 func TestNoSelectionChangeDuringEdit(t *testing.T) {
-	c := &ToDoContent{}
+	c := &model.ToDoContent{}
 	c.InitializeNew()
 	c.AddItem(0, 0, "task 1", "", 2, "", "")
 	c.AddItem(0, 1, "task 2", "", 2, "", "")
 	app := tview.NewApplication()
-	l := NewLanes(c, app, "", t.TempDir())
+	l := NewLanes(c, app, "", t.TempDir(), "")
 
 	l.CmdEditTask()
 
@@ -27,12 +29,12 @@ func TestNoSelectionChangeDuringEdit(t *testing.T) {
 }
 
 func TestNoSelectionChangeDuringAdd(t *testing.T) {
-	c := &ToDoContent{}
+	c := &model.ToDoContent{}
 	c.InitializeNew()
 	c.AddItem(0, 0, "task 1", "", 2, "", "")
 	c.AddItem(0, 1, "task 2", "", 2, "", "")
 	app := tview.NewApplication()
-	l := NewLanes(c, app, "", t.TempDir())
+	l := NewLanes(c, app, "", t.TempDir(), "")
 
 	l.CmdAddTask()
 
@@ -45,10 +47,10 @@ func TestNoSelectionChangeDuringAdd(t *testing.T) {
 }
 
 func TestAddTaskFocus(t *testing.T) {
-	c := &ToDoContent{}
+	c := &model.ToDoContent{}
 	c.InitializeNew()
 	app := tview.NewApplication()
-	l := NewLanes(c, app, "", t.TempDir())
+	l := NewLanes(c, app, "", t.TempDir(), "")
 
 	l.CmdAddTask()
 
@@ -58,11 +60,11 @@ func TestAddTaskFocus(t *testing.T) {
 }
 
 func TestEditTaskFocus(t *testing.T) {
-	c := &ToDoContent{}
+	c := &model.ToDoContent{}
 	c.InitializeNew()
 	c.AddItem(0, 0, "task", "", 2, "", "")
 	app := tview.NewApplication()
-	l := NewLanes(c, app, "", t.TempDir())
+	l := NewLanes(c, app, "", t.TempDir(), "")
 
 	l.CmdEditTask()
 
@@ -72,7 +74,7 @@ func TestEditTaskFocus(t *testing.T) {
 }
 
 func TestMouseCaptureDuringAdd(t *testing.T) {
-	c := &ToDoContent{}
+	c := &model.ToDoContent{}
 	c.InitializeNew()
 	c.AddItem(0, 0, "task 1", "", 2, "", "")
 	app := tview.NewApplication()
@@ -81,7 +83,7 @@ func TestMouseCaptureDuringAdd(t *testing.T) {
 		called = true
 		return event, action
 	})
-	l := NewLanes(c, app, "", t.TempDir())
+	l := NewLanes(c, app, "", t.TempDir(), "")
 
 	l.CmdAddTask()
 	event := tcell.NewEventMouse(50, 50, tcell.Button1, 0)
@@ -101,7 +103,7 @@ func TestMouseCaptureDuringAdd(t *testing.T) {
 }
 
 func TestInputCaptureDuringAdd(t *testing.T) {
-	c := &ToDoContent{}
+	c := &model.ToDoContent{}
 	c.InitializeNew()
 	app := tview.NewApplication()
 	called := false
@@ -109,7 +111,7 @@ func TestInputCaptureDuringAdd(t *testing.T) {
 		called = true
 		return nil
 	})
-	l := NewLanes(c, app, "", t.TempDir())
+	l := NewLanes(c, app, "", t.TempDir(), "")
 
 	l.CmdAddTask()
 	key := tcell.NewEventKey(tcell.KeyF1, rune(0), tcell.ModNone)

--- a/internal/ui/ui_modes.go
+++ b/internal/ui/ui_modes.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 import (
 	"errors"

--- a/internal/ui/ui_notes.go
+++ b/internal/ui/ui_notes.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 import (
 	"fmt"
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/cklukas/todo/internal/util"
 	"github.com/gdamore/tcell/v2"
 )
 
@@ -75,21 +76,21 @@ func (l *Lanes) CmdSelectNote() {
 
 func (l *Lanes) up() {
 	currentPos := l.lanes[l.active].GetCurrentItem()
-	newPos := normPos(currentPos-1, l.lanes[l.active].GetItemCount())
+	newPos := util.NormPos(currentPos-1, l.lanes[l.active].GetItemCount())
 	l.content.MoveItem(l.active, currentPos, l.active, newPos)
 	l.redrawLane(l.active, newPos)
 }
 
 func (l *Lanes) down() {
 	currentPos := l.lanes[l.active].GetCurrentItem()
-	newPos := normPos(currentPos+1, l.lanes[l.active].GetItemCount())
+	newPos := util.NormPos(currentPos+1, l.lanes[l.active].GetItemCount())
 	l.content.MoveItem(l.active, currentPos, l.active, newPos)
 	l.redrawLane(l.active, newPos)
 }
 
 func (l *Lanes) moveSelectionLeft() {
 	currentPos := l.lanes[l.active].GetCurrentItem()
-	newLane := normPos(l.active-1, len(l.lanes))
+	newLane := util.NormPos(l.active-1, len(l.lanes))
 	newPos := l.lanes[newLane].GetCurrentItem()
 	l.content.MoveItem(l.active, currentPos, newLane, newPos)
 	l.redrawLane(l.active, currentPos)
@@ -101,7 +102,7 @@ func (l *Lanes) moveSelectionLeft() {
 
 func (l *Lanes) moveSelectionRight() {
 	currentPos := l.lanes[l.active].GetCurrentItem()
-	newLane := normPos(l.active+1, len(l.lanes))
+	newLane := util.NormPos(l.active+1, len(l.lanes))
 	newPos := l.lanes[newLane].GetCurrentItem()
 	l.content.MoveItem(l.active, currentPos, newLane, newPos)
 	l.redrawLane(l.active, currentPos)
@@ -176,7 +177,7 @@ func (l *Lanes) editNote() {
 					}
 				}
 
-				words, err := Split(editorCmd)
+				words, err := util.Split(editorCmd)
 				if err != nil {
 					l.app.Stop()
 					log.Fatal(err)

--- a/internal/ui/ui_sort.go
+++ b/internal/ui/ui_sort.go
@@ -1,4 +1,4 @@
-package cmd
+package ui
 
 func (l *Lanes) CmdSortDialog() {
 	l.saveActive()

--- a/internal/util/file_writable_unix.go
+++ b/internal/util/file_writable_unix.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package cmd
+package util
 
 import (
 	"os"
@@ -10,7 +10,7 @@ import (
 )
 
 // fileWritable reports whether the given path is writable by the current user on Unix-like systems.
-func fileWritable(path string) bool {
+func FileWritable(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
 		return false

--- a/internal/util/file_writable_windows.go
+++ b/internal/util/file_writable_windows.go
@@ -1,12 +1,12 @@
 //go:build windows
 
-package cmd
+package util
 
 import "os"
 
 // fileWritable reports whether the given path is writable by the current user on Windows.
 // It only checks the write permission bits because Windows does not expose POSIX UID/GID.
-func fileWritable(path string) bool {
+func FileWritable(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
 		return false

--- a/internal/util/position.go
+++ b/internal/util/position.go
@@ -1,0 +1,12 @@
+package util
+
+// NormPos normalizes a position within a list of given length.
+func NormPos(pos, length int) int {
+	for pos < 0 {
+		pos += length
+	}
+	if length > 0 {
+		pos %= length
+	}
+	return pos
+}

--- a/internal/util/prefix.go
+++ b/internal/util/prefix.go
@@ -1,0 +1,32 @@
+package util
+
+import "strings"
+
+// RemovePrefix returns text without a leading color prefix.
+func RemovePrefix(text string) string {
+	if strings.HasPrefix(text, "[") {
+		if idx := strings.Index(text, "]"); idx > 0 {
+			return text[idx+1:]
+		}
+	}
+	return text
+}
+
+// ApplyPrefix adds or replaces the color prefix.
+func ApplyPrefix(text, color string) string {
+	base := RemovePrefix(text)
+	if color == "" || color == "default" {
+		return base
+	}
+	return "[" + color + "]" + base
+}
+
+// ParsePrefix splits a title into color prefix and the remaining text.
+func ParsePrefix(text string) (string, string) {
+	if strings.HasPrefix(text, "[") {
+		if idx := strings.Index(text, "]"); idx > 0 {
+			return strings.ToLower(text[1:idx]), text[idx+1:]
+		}
+	}
+	return "", text
+}

--- a/internal/util/split.go
+++ b/internal/util/split.go
@@ -1,4 +1,4 @@
-package cmd
+package util
 
 // source: https://github.com/kballard/go-shellquote/blob/master/unquote.go
 // MIT License

--- a/internal/util/version.go
+++ b/internal/util/version.go
@@ -1,0 +1,118 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+var LatestReleaseURL = "https://api.github.com/repos/cklukas/todo/releases/latest"
+
+func LatestReleaseInfo(current string) (string, bool, error) {
+	tag, err := GetLatestReleaseTag()
+	if err != nil {
+		return "", false, err
+	}
+	newer, err := IsReleaseNewer(tag, current)
+	if err != nil {
+		return tag, false, err
+	}
+	return tag, newer, nil
+}
+
+func GetLatestReleaseTag() (string, error) {
+	resp, err := http.Get(LatestReleaseURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var data struct {
+		Tag string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", err
+	}
+	return data.Tag, nil
+}
+
+func VersionParts(v string) ([]int, error) {
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return []int{0}, nil
+	}
+	parts := strings.Split(v, ".")
+	res := make([]int, len(parts))
+	for i, p := range parts {
+		if p == "" {
+			res[i] = 0
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = n
+	}
+	return res, nil
+}
+
+func IsReleaseNewer(release, current string) (bool, error) {
+	r, err := VersionParts(release)
+	if err != nil {
+		return false, err
+	}
+	c, err := VersionParts(current)
+	if err != nil {
+		return false, err
+	}
+	l := len(r)
+	if len(c) > l {
+		l = len(c)
+	}
+	for i := 0; i < l; i++ {
+		rv, cv := 0, 0
+		if i < len(r) {
+			rv = r[i]
+		}
+		if i < len(c) {
+			cv = c[i]
+		}
+		if rv > cv {
+			return true, nil
+		} else if rv < cv {
+			return false, nil
+		}
+	}
+	return false, nil
+}
+
+func IsLocalDevelopmentVersion(v string) bool {
+	return v == "" || strings.Contains(v, "..")
+}
+
+func AssetNameForCurrentOS() (string, error) {
+	switch runtime.GOOS {
+	case "windows":
+		if runtime.GOARCH == "amd64" {
+			return "todo.exe", nil
+		}
+	case "linux":
+		if runtime.GOARCH == "amd64" {
+			return "todo_linux_amd64", nil
+		}
+		if runtime.GOARCH == "arm64" {
+			return "todo_linux_arm64", nil
+		}
+	case "darwin":
+		if runtime.GOARCH == "arm64" {
+			return "todo_mac_arm64", nil
+		}
+	}
+	return "", fmt.Errorf("unsupported OS/ARCH combination %s/%s", runtime.GOOS, runtime.GOARCH)
+}


### PR DESCRIPTION
## Summary
- move helper and UI files into new internal packages
- update imports and add exported helpers
- introduce util package with reusable helpers
- adapt commands and tests to new structure

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68475efa11f88330941a0516b02be8d2