### PR TITLE
Improve lane UI

### DIFF
--- a/internal/ui/color_dialog.go
+++ b/internal/ui/color_dialog.go
@@ -22,7 +22,7 @@ func (m *ColorModal) GetFrame() *tview.Frame {
 func NewColorModal(title, current string) *ColorModal {
 	form := tview.NewForm()
 	m := &ColorModal{Form: form, DialogHeight: 7, frame: tview.NewFrame(form), optionIndex: 0,
-		options: []string{"", "blue", "green", "red", "yellow"}, done: nil}
+		options: []string{"", "blue", "green", "red", "yellow", "white", "darkcyan", "black", "darkmagenta"}, done: nil}
 
 	form.SetCancelFunc(func() {
 		if m.done != nil {
@@ -30,7 +30,7 @@ func NewColorModal(title, current string) *ColorModal {
 		}
 	})
 
-	labels := []string{"default", "blue", "green", "red", "yellow"}
+	labels := []string{"default", "blue", "green", "red", "yellow", "white", "darkcyan", "black", "darkmagenta"}
 	idx := 0
 	for i, v := range m.options {
 		if v == current {

--- a/internal/ui/inputmodal.go
+++ b/internal/ui/inputmodal.go
@@ -56,7 +56,7 @@ func (m *ModalInput) updateOKButton() {
 func NewModalInput(title string) *ModalInput {
 	form := tview.NewForm()
 
-	m := &ModalInput{Form: form, DialogHeight: 9, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, color: "", showColor: false, colors: []string{"default", "blue", "green", "red", "yellow"}, createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
+	m := &ModalInput{Form: form, DialogHeight: 9, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, color: "", showColor: false, colors: []string{"default", "blue", "green", "red", "yellow", "white", "darkcyan", "black", "darkmagenta"}, createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
 
 	form.SetCancelFunc(func() {
 		if m.done != nil {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -71,10 +71,23 @@ func (l *Lanes) redrawLane(laneIndex, active int) error {
 	l.content.SortLane(laneIndex)
 	l.lanes[laneIndex].Clear()
 	now := time.Now()
+	laneBg := tview.Styles.PrimitiveBackgroundColor
+	if col := l.content.GetLaneColor(laneIndex); col != "" {
+		laneBg = tcell.GetColor(col)
+	}
+
 	for _, item := range l.content.GetLaneItems(laneIndex) {
 		title := item.Title
 		if item.Color != "" {
-			title = "[" + item.Color + "]" + title
+			if tcell.GetColor(item.Color) == laneBg {
+				altBg := "white"
+				if laneBg == tcell.ColorWhite {
+					altBg = "black"
+				}
+				title = "[" + item.Color + ":" + altBg + "]" + title
+			} else {
+				title = "[" + item.Color + "]" + title
+			}
 		}
 		if suffix := dueSuffix(item.Due, now); suffix != "" {
 			title += " " + suffix

--- a/internal/ui/ui_lanes.go
+++ b/internal/ui/ui_lanes.go
@@ -273,22 +273,26 @@ func (l *Lanes) CmdLanesCmds() {
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 			switch buttonLabel {
 			case "Sort Tasks":
-				l.pages.HidePage("laneDialog")
+				l.hideDialog("laneDialog")
 				l.CmdSortDialog()
 				return
 			case "Color":
+				l.hideDialog("laneDialog")
 				l.laneColorCommand(initActiveLane)
 				return
 			case "Rename":
+				l.hideDialog("laneDialog")
 				l.renameLaneCommand(initActiveLane)
 				return
 			case "Add to left":
 				addToLeft = true
 				fallthrough
 			case "Add to right":
+				l.hideDialog("laneDialog")
 				l.addLaneLeftRightCommand(addToLeft, initActiveLane)
 				return
 			case "Merge/Remove":
+				l.hideDialog("laneDialog")
 				l.removeMergeLaneDialog(initActiveLane)
 				return
 			case "Cancel":
@@ -297,33 +301,38 @@ func (l *Lanes) CmdLanesCmds() {
 				// l.nextMode = buttonLabel
 				// l.app.Stop()
 			}
-			l.pages.HidePage("laneDialog")
+			l.hideDialog("laneDialog")
 			l.setActiveIndex(initActiveLane)
 		})
 
 	lanePage.SetFocus(0)
 	l.pages.AddPage("laneDialog", lanePage, false, true)
+	l.dialogActive = true
+	l.activeDialog = nil
+	l.pages.ShowPage("laneDialog")
+	l.app.SetFocus(lanePage)
 }
 
 func (l *Lanes) renameLaneCommand(initActiveLane int) {
 	addLaneDialog := NewModalInputLane("Rename Lane", "", 7, l.GetActiveLaneName())
 
 	addLaneDialog.SetDoneFunc(func(lane, _ string, success bool) {
-		l.pages.HidePage("addLane")
+		l.hideDialog("addLane")
 		l.setActiveIndex(initActiveLane)
 		l.content.SetLaneTitle(initActiveLane, lane)
 		l.content.Save()
 		l.RedrawAllLanes()
 	})
 
-	l.pages.HidePage("laneDialog")
+	l.hideDialog("laneDialog")
 	l.pages.AddPage("addLane", addLaneDialog, false, true)
+	l.showDialog("addLane", addLaneDialog)
 }
 
 func (l *Lanes) laneColorCommand(initActiveLane int) {
 	colorDlg := NewColorModal("Lane Color", l.content.GetLaneColor(l.active))
 	colorDlg.SetDoneFunc(func(color string, success bool) {
-		l.pages.HidePage("laneColor")
+		l.hideDialog("laneColor")
 		l.setActiveIndex(initActiveLane)
 		if success {
 			l.content.SetLaneColor(initActiveLane, color)
@@ -332,7 +341,7 @@ func (l *Lanes) laneColorCommand(initActiveLane int) {
 		}
 	})
 
-	l.pages.HidePage("laneDialog")
+	l.hideDialog("laneDialog")
 	l.pages.AddPage("laneColor", colorDlg, false, true)
 	l.showDialog("laneColor", colorDlg)
 }
@@ -355,12 +364,13 @@ func (l *Lanes) addLaneLeftRightCommand(addToLeft bool, initActiveLane int) {
 			l.nextLaneFocus = laneIndex
 			l.app.Stop()
 		}
-		l.pages.HidePage("addLane")
+		l.hideDialog("addLane")
 		l.setActiveIndex(initActiveLane)
 	})
 
-	l.pages.HidePage("laneDialog")
+	l.hideDialog("laneDialog")
 	l.pages.AddPage("addLane", addLaneDialog, false, true)
+	l.showDialog("addLane", addLaneDialog)
 }
 
 func (l *Lanes) removeMergeLaneDialog(initActiveLane int) {
@@ -391,8 +401,12 @@ func (l *Lanes) removeMergeLaneDialog(initActiveLane int) {
 		l.removeMergeLaneCommand(buttonIndex, buttonLabel, targetLanes, initActiveLane)
 	})
 
-	l.pages.HidePage("laneDialog")
+	l.hideDialog("laneDialog")
 	l.pages.AddPage("removeLane", removeLaneDialog, false, true)
+	l.dialogActive = true
+	l.activeDialog = nil
+	l.pages.ShowPage("removeLane")
+	l.app.SetFocus(removeLaneDialog)
 }
 
 func (l *Lanes) removeMergeLaneCommand(buttonIndex int, buttonLabel string, targetLanes []string, initActiveLane int) {
@@ -438,6 +452,6 @@ func (l *Lanes) removeMergeLaneCommand(buttonIndex int, buttonLabel string, targ
 		return
 	}
 
-	l.pages.HidePage("removeLane")
+	l.hideDialog("removeLane")
 	l.setActiveIndex(initActiveLane)
 }

--- a/internal/ui/ui_lanes_test.go
+++ b/internal/ui/ui_lanes_test.go
@@ -133,3 +133,35 @@ func TestInputCaptureDuringAdd(t *testing.T) {
 		t.Fatalf("original input capture not called after dialog")
 	}
 }
+
+func TestInputCaptureDuringLaneDialog(t *testing.T) {
+	c := &model.ToDoContent{}
+	c.InitializeNew()
+	app := tview.NewApplication()
+	called := false
+	app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		called = true
+		return nil
+	})
+	l := NewLanes(c, app, "", t.TempDir(), "")
+
+	l.CmdLanesCmds()
+	key := tcell.NewEventKey(tcell.KeyF1, rune(0), tcell.ModNone)
+	ret := app.GetInputCapture()(key)
+	if ret != key {
+		t.Fatalf("input capture modified event")
+	}
+	if called {
+		t.Fatalf("original input capture called during dialog")
+	}
+
+	l.hideDialog("laneDialog")
+	called = false
+	ret = app.GetInputCapture()(key)
+	if ret != nil {
+		t.Fatalf("expected nil from original capture")
+	}
+	if !called {
+		t.Fatalf("original input capture not called after dialog")
+	}
+}


### PR DESCRIPTION
## Summary
- extend available lane colors and color dropdown selections
- ensure text remains readable when task color matches lane background
- disable hotkeys when lane dialog is active
- test input capture during lane dialog

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684817f3bf80833095ef813bab35b727