### PR TITLE
Improve color previews

### DIFF
--- a/cmd/color_style_test.go
+++ b/cmd/color_style_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/cklukas/todo/internal/ui"
+	"github.com/rivo/tview"
+)
+
+func getDropDownTexts(dd *tview.DropDown) []string {
+	v := reflect.ValueOf(dd).Elem().FieldByName("options")
+	res := make([]string, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		res[i] = v.Index(i).Elem().FieldByName("Text").String()
+	}
+	return res
+}
+
+func getDropDownTextsFromCI(ci *ui.ColorInput) []string {
+	v := reflect.ValueOf(ci).Elem().FieldByName("dropdown")
+	dd := (*tview.DropDown)(unsafe.Pointer(v.Pointer()))
+	return getDropDownTexts(dd)
+}
+
+func TestColorModalLabelsHaveBackground(t *testing.T) {
+	dlg := ui.NewColorModal("Color", "")
+	dd := dlg.GetFormItem(0).(*tview.DropDown)
+	texts := getDropDownTexts(dd)
+	if texts[1] != "[black:black]black" {
+		t.Fatalf("color modal text for black wrong: %s", texts[1])
+	}
+}
+
+func TestColorInputLabelsUseLaneBackground(t *testing.T) {
+	ci := ui.NewColorInput("Title:", "yellow", []string{"default", "red"})
+	texts := getDropDownTextsFromCI(ci)
+	if texts[1] != "[red:yellow]red" {
+		t.Fatalf("color input text for red wrong: %s", texts[1])
+	}
+}

--- a/internal/ui/color_dialog.go
+++ b/internal/ui/color_dialog.go
@@ -30,12 +30,16 @@ func NewColorModal(title, current string) *ColorModal {
 		}
 	})
 
-	labels := []string{"default", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "lightblue", "lightgreen", "lightcyan", "lightcoral", "fuchsia", "yellow"}
+	labels := make([]string, len(m.options))
 	idx := 0
 	for i, v := range m.options {
+		if i == 0 || v == "" {
+			labels[i] = "default"
+		} else {
+			labels[i] = "[black:" + v + "]" + v
+		}
 		if v == current {
 			idx = i
-			break
 		}
 	}
 	m.optionIndex = idx

--- a/internal/ui/colorinput.go
+++ b/internal/ui/colorinput.go
@@ -8,14 +8,15 @@ import (
 // ColorInput is a form item that combines an input field with a color drop-down.
 type ColorInput struct {
 	*tview.Flex
-	input    *tview.InputField
-	dropdown *tview.DropDown
-	colors   []string
+	input     *tview.InputField
+	dropdown  *tview.DropDown
+	colors    []string
+	laneColor string
 }
 
 // NewColorInput creates a new ColorInput. colors is a slice of color names. The
 // first entry should be "default".
-func NewColorInput(label string, colors []string) *ColorInput {
+func NewColorInput(label, laneColor string, colors []string) *ColorInput {
 	input := tview.NewInputField().SetLabel(label)
 	dd := tview.NewDropDown()
 	dd.SetLabel("")
@@ -24,14 +25,18 @@ func NewColorInput(label string, colors []string) *ColorInput {
 		if i == 0 || c == "" {
 			disp[i] = "default"
 		} else {
-			disp[i] = "[" + c + "]" + c
+			if laneColor != "" {
+				disp[i] = "[" + c + ":" + laneColor + "]" + c
+			} else {
+				disp[i] = "[" + c + "]" + c
+			}
 		}
 	}
 	dd.SetOptions(disp, nil)
 	flex := tview.NewFlex().SetDirection(tview.FlexColumn)
 	flex.AddItem(input, 0, 4, true)
 	flex.AddItem(dd, 0, 1, false)
-	return &ColorInput{flex, input, dd, colors}
+	return &ColorInput{flex, input, dd, colors, laneColor}
 }
 
 // GetLabel returns the item's label text.

--- a/internal/ui/colorinput_test.go
+++ b/internal/ui/colorinput_test.go
@@ -29,7 +29,7 @@ func TestApplyPrefix(t *testing.T) {
 }
 
 func TestColorInputTabSwitch(t *testing.T) {
-	ci := NewColorInput("Title:", []string{"default", "blue"})
+	ci := NewColorInput("Title:", "", []string{"default", "blue"})
 	focused := tview.Primitive(nil)
 	setFocus := func(p tview.Primitive) { focused = p; p.Focus(func(p tview.Primitive) {}) }
 
@@ -48,7 +48,7 @@ func TestColorInputTabSwitch(t *testing.T) {
 }
 
 func TestColorInputFinishedFunc(t *testing.T) {
-	ci := NewColorInput("Title:", []string{"default", "blue"})
+	ci := NewColorInput("Title:", "", []string{"default", "blue"})
 	called := false
 	ci.SetFinishedFunc(func(k tcell.Key) { called = true })
 

--- a/internal/ui/inputmodal.go
+++ b/internal/ui/inputmodal.go
@@ -23,6 +23,7 @@ type ModalInput struct {
 	color        string
 	showColor    bool
 	colors       []string
+	laneColor    string
 	createdBy    string
 	created      string
 	updatedBy    string
@@ -56,7 +57,7 @@ func (m *ModalInput) updateOKButton() {
 func NewModalInput(title string) *ModalInput {
 	form := tview.NewForm()
 
-	m := &ModalInput{Form: form, DialogHeight: 9, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, color: "", showColor: false, colors: []string{"default", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "lightblue", "lightgreen", "lightcyan", "lightcoral", "fuchsia", "yellow"}, createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
+	m := &ModalInput{Form: form, DialogHeight: 9, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, color: "", showColor: false, colors: []string{"default", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "lightblue", "lightgreen", "lightcyan", "lightcoral", "fuchsia", "yellow"}, laneColor: "", createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
 
 	form.SetCancelFunc(func() {
 		if m.done != nil {
@@ -104,7 +105,7 @@ func NewModalInput(title string) *ModalInput {
 
 func NewModalInputMode(title, modeDirectory string) *ModalInput {
 	form := tview.NewForm()
-	m := &ModalInput{Form: form, DialogHeight: 8, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
+	m := &ModalInput{Form: form, DialogHeight: 8, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, laneColor: "", createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
 
 	form.AddInputField("Mode:", "", 50, nil, func(text string) {
 		m.main = text
@@ -140,7 +141,7 @@ func NewModalInputMode(title, modeDirectory string) *ModalInput {
 
 func NewModalInputLane(title, laneDescription string, dialogHeight int, initialInput1 string) *ModalInput {
 	form := tview.NewForm()
-	m := &ModalInput{Form: form, DialogHeight: dialogHeight, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
+	m := &ModalInput{Form: form, DialogHeight: dialogHeight, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, laneColor: "", createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
 	m.main = initialInput1
 
 	form.AddInputField("Lane:", initialInput1, 50, nil, func(text string) {
@@ -184,7 +185,7 @@ func (m *ModalInput) SetValue(text string, secondary string, due string) {
 
 	var titleField *tview.InputField
 	if m.showColor {
-		ci := NewColorInput("Title:", m.colors)
+		ci := NewColorInput("Title:", m.laneColor, m.colors)
 		titleField = ci.input
 		titleField.SetText(text)
 		titleField.SetChangedFunc(func(text string) {
@@ -338,6 +339,11 @@ func (m *ModalInput) SetPriority(value int) {
 func (m *ModalInput) SetColor(color string) {
 	m.color = color
 	m.showColor = true
+}
+
+// SetLaneColor sets the lane background color used for the color dropdown.
+func (m *ModalInput) SetLaneColor(color string) {
+	m.laneColor = color
 }
 
 // SetDue enables a due date input field with the given value using locale formatting.

--- a/internal/ui/ui_notes.go
+++ b/internal/ui/ui_notes.go
@@ -19,6 +19,7 @@ func (l *Lanes) CmdAddTask() {
 	l.add.ClearExtras()
 	l.add.SetPriority(2)
 	l.add.SetDue("")
+	l.add.SetLaneColor(l.content.GetLaneColor(l.active))
 	l.add.SetColor("")
 	l.add.SetValue("", fmt.Sprintf("created: %v", now.Format(dueLayout())), "")
 	l.showDialog("add", l.add)
@@ -38,6 +39,7 @@ func (l *Lanes) CmdEditTask() {
 			updatedBy = item.UpdatedByName
 		}
 		l.edit.SetInfo(item.UserName, createdStr, updatedBy, updatedStr)
+		l.edit.SetLaneColor(l.content.GetLaneColor(l.active))
 		l.edit.SetColor(item.Color)
 		l.edit.SetValue(item.Title, item.Secondary, isoToLocal(item.Due))
 		l.showDialog("edit", l.edit)


### PR DESCRIPTION
## Summary
- preview lane colors in dropdowns
- show task color options with lane background color
- keep track of lane background color in modal
- unit tests for dropdown color styling

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848241b59688330bb33750cdc9cf404