### PR TITLE
Improve color dropdown display

### DIFF
--- a/cmd/color_style_test.go
+++ b/cmd/color_style_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -28,15 +29,17 @@ func TestColorModalLabelsHaveBackground(t *testing.T) {
 	dlg := ui.NewColorModal("Color", "")
 	dd := dlg.GetFormItem(0).(*tview.DropDown)
 	texts := getDropDownTexts(dd)
-	if texts[1] != "[black:black]black" {
-		t.Fatalf("color modal text for black wrong: %s", texts[1])
+	trimmed := strings.TrimRight(texts[1], " ")
+	if trimmed != "[black:black]black" || len(texts[1]) == len(trimmed) {
+		t.Fatalf("color modal text for black wrong: %q", texts[1])
 	}
 }
 
 func TestColorInputLabelsUseLaneBackground(t *testing.T) {
 	ci := ui.NewColorInput("Title:", "yellow", []string{"default", "red"})
 	texts := getDropDownTextsFromCI(ci)
-	if texts[1] != "[red:yellow]red" {
-		t.Fatalf("color input text for red wrong: %s", texts[1])
+	trimmed := strings.TrimRight(texts[1], " ")
+	if trimmed != "[red:yellow]red" || len(texts[1]) == len(trimmed) {
+		t.Fatalf("color input text for red wrong: %q", texts[1])
 	}
 }

--- a/cmd/dos_colors_test.go
+++ b/cmd/dos_colors_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDOSColorLists(t *testing.T) {
-	wantInput := []string{"default", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "lightblue", "lightgreen", "lightcyan", "lightcoral", "fuchsia", "yellow"}
+	wantInput := []string{"default", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "darkblue", "darkgreen", "darkcyan", "darkred", "fuchsia", "yellow"}
 	mi := ui.NewModalInput("Add Task")
 	v := reflect.ValueOf(mi).Elem().FieldByName("colors")
 	gotInput := make([]string, v.Len())
@@ -19,7 +19,7 @@ func TestDOSColorLists(t *testing.T) {
 		t.Fatalf("modal input colors %v, want %v", gotInput, wantInput)
 	}
 
-	wantModal := []string{"", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "lightblue", "lightgreen", "lightcyan", "lightcoral", "fuchsia", "yellow"}
+	wantModal := []string{"", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "darkblue", "darkgreen", "darkcyan", "darkred", "fuchsia", "yellow"}
 	cm := ui.NewColorModal("Color", "")
 	v2 := reflect.ValueOf(cm).Elem().FieldByName("options")
 	gotModal := make([]string, v2.Len())

--- a/internal/ui/color_dialog.go
+++ b/internal/ui/color_dialog.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"strings"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -22,7 +24,7 @@ func (m *ColorModal) GetFrame() *tview.Frame {
 func NewColorModal(title, current string) *ColorModal {
 	form := tview.NewForm()
 	m := &ColorModal{Form: form, DialogHeight: 7, frame: tview.NewFrame(form), optionIndex: 0,
-		options: []string{"", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "lightblue", "lightgreen", "lightcyan", "lightcoral", "fuchsia", "yellow"}, done: nil}
+		options: []string{"", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "darkblue", "darkgreen", "darkcyan", "darkred", "fuchsia", "yellow"}, done: nil}
 
 	form.SetCancelFunc(func() {
 		if m.done != nil {
@@ -32,15 +34,30 @@ func NewColorModal(title, current string) *ColorModal {
 
 	labels := make([]string, len(m.options))
 	idx := 0
+	maxLen := 0
 	for i, v := range m.options {
+		name := v
 		if i == 0 || v == "" {
-			labels[i] = "default"
-		} else {
-			labels[i] = "[black:" + v + "]" + v
+			name = "default"
+		}
+		if len(name) > maxLen {
+			maxLen = len(name)
 		}
 		if v == current {
 			idx = i
 		}
+	}
+	for i, v := range m.options {
+		name := v
+		var style string
+		if i == 0 || v == "" {
+			name = "default"
+			style = "[black:white]"
+		} else {
+			style = "[black:" + v + "]"
+		}
+		pad := strings.Repeat(" ", maxLen-len(name))
+		labels[i] = style + name + pad
 	}
 	m.optionIndex = idx
 	form.AddDropDown("Color:", labels, idx, func(option string, index int) {

--- a/internal/ui/color_dialog_test.go
+++ b/internal/ui/color_dialog_test.go
@@ -1,8 +1,10 @@
 package ui
 
 import (
+	"github.com/cklukas/todo/internal/util"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"strings"
 	"testing"
 )
 
@@ -10,7 +12,7 @@ func TestNewColorModalDefaultSelected(t *testing.T) {
 	dlg := NewColorModal("Color", "")
 	item := dlg.GetFormItem(0).(*tview.DropDown)
 	_, text := item.GetCurrentOption()
-	if text != "default" {
+	if strings.TrimSpace(util.RemovePrefix(text)) != "default" {
 		t.Fatalf("expected initial option 'default', got '%s'", text)
 	}
 	if dlg.GetButtonIndex("Cancel") == -1 {

--- a/internal/ui/colorinput.go
+++ b/internal/ui/colorinput.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"strings"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -21,16 +23,30 @@ func NewColorInput(label, laneColor string, colors []string) *ColorInput {
 	dd := tview.NewDropDown()
 	dd.SetLabel("")
 	disp := make([]string, len(colors))
+	maxLen := 0
 	for i, c := range colors {
+		name := c
 		if i == 0 || c == "" {
-			disp[i] = "default"
-		} else {
-			if laneColor != "" {
-				disp[i] = "[" + c + ":" + laneColor + "]" + c
-			} else {
-				disp[i] = "[" + c + "]" + c
-			}
+			name = "default"
 		}
+		if len(name) > maxLen {
+			maxLen = len(name)
+		}
+	}
+	for i, c := range colors {
+		name := c
+		fg := c
+		bg := laneColor
+		if i == 0 || c == "" {
+			name = "default"
+			fg = "black"
+		}
+		style := "[" + fg
+		if bg != "" {
+			style += ":" + bg
+		}
+		style += "]"
+		disp[i] = style + name + strings.Repeat(" ", maxLen-len(name))
 	}
 	dd.SetOptions(disp, nil)
 	flex := tview.NewFlex().SetDirection(tview.FlexColumn)

--- a/internal/ui/inputmodal.go
+++ b/internal/ui/inputmodal.go
@@ -57,7 +57,7 @@ func (m *ModalInput) updateOKButton() {
 func NewModalInput(title string) *ModalInput {
 	form := tview.NewForm()
 
-	m := &ModalInput{Form: form, DialogHeight: 9, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, color: "", showColor: false, colors: []string{"default", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "lightblue", "lightgreen", "lightcyan", "lightcoral", "fuchsia", "yellow"}, laneColor: "", createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
+	m := &ModalInput{Form: form, DialogHeight: 9, frame: tview.NewFrame(form), main: "", secondary: "", due: "", priority: 2, showPriority: false, showDue: false, color: "", showColor: false, colors: []string{"default", "black", "blue", "green", "aqua", "red", "purple", "brown", "silver", "gray", "darkblue", "darkgreen", "darkcyan", "darkred", "fuchsia", "yellow"}, laneColor: "", createdBy: "", created: "", updatedBy: "", updated: "", titleField: nil, okButton: nil, done: nil}
 
 	form.SetCancelFunc(func() {
 		if m.done != nil {


### PR DESCRIPTION
## Summary
- use darker color names for lane color dropdown
- add padding so dropdown options show full background color
- show lane background for task color dropdown options
- update tests to verify new styles

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68483350420c83308e48d7d46eacc1e1