### PR TITLE
Fix lane highlighting

### DIFF
--- a/internal/ui/ui_lanes.go
+++ b/internal/ui/ui_lanes.go
@@ -72,6 +72,7 @@ func NewLanes(content *model.ToDoContent, app *tview.Application, mode, todoDirM
 	flex := tview.NewFlex()
 	for i := 0; i < l.content.GetNumLanes(); i++ {
 		l.lanes[i] = tview.NewList()
+		l.lanes[i].SetSelectedFocusOnly(true)
 		if col := l.content.GetLaneColor(i); col != "" {
 			l.lanes[i].SetBackgroundColor(tcell.GetColor(col))
 		}


### PR DESCRIPTION
## Summary
- update lane initialization so items in inactive lanes are not highlighted

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68483ac37940833082ceab858be69f6c