### PR TITLE
Fix status bar background color

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -152,6 +152,8 @@ func getStatusBar(lanes *ui.Lanes, mode string) *tview.Flex {
 		AddItem(bMode, 2+len(mode), 1, false).
 		AddItem(bMoveHelp, 38, 1, false)
 
+	defaultStatusBarMenuItems.SetBackgroundColor(tcell.ColorLightGray)
+
 	return defaultStatusBarMenuItems
 }
 

--- a/cmd/statusbar_test.go
+++ b/cmd/statusbar_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cklukas/todo/internal/model"
+	"github.com/cklukas/todo/internal/ui"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func TestStatusBarUsesGrayBackground(t *testing.T) {
+	c := &model.ToDoContent{}
+	c.InitializeNew()
+	app := tview.NewApplication()
+	lanes := ui.NewLanes(c, app, "main", t.TempDir(), "")
+
+	status := getStatusBar(lanes, "main")
+
+	if status.GetBackgroundColor() != tcell.ColorLightGray {
+		t.Fatalf("status bar background color %v, want %v", status.GetBackgroundColor(), tcell.ColorLightGray)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure status bar flex uses light gray background
- add regression test for status bar color

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_684887f9e2e48330af05748acd4b6e1f