### PR TITLE
Fix locale handling in tests

### DIFF
--- a/internal/ui/datefmt_test.go
+++ b/internal/ui/datefmt_test.go
@@ -25,6 +25,7 @@ func TestIsoTimeToLocal(t *testing.T) {
 	iso := "2025-03-23T14:11:51Z"
 
 	os.Unsetenv("LC_TIME")
+	os.Unsetenv("AppleLocale")
 	t1, _ := time.Parse(time.RFC3339, iso)
 	want := t1.Local().Format(dueLayout() + " 15:04")
 	if got := isoTimeToLocal(iso); got != want {
@@ -32,10 +33,12 @@ func TestIsoTimeToLocal(t *testing.T) {
 	}
 
 	os.Setenv("LC_TIME", "en_US")
+	os.Setenv("AppleLocale", "en_US")
 	t2, _ := time.Parse(time.RFC3339, iso)
 	want = t2.Local().Format(dueLayout() + " 15:04")
 	if got := isoTimeToLocal(iso); got != want {
 		t.Fatalf("isoTimeToLocal US got %q want %q", got, want)
 	}
 	os.Unsetenv("LC_TIME")
+	os.Unsetenv("AppleLocale")
 }

--- a/internal/ui/due_test.go
+++ b/internal/ui/due_test.go
@@ -21,6 +21,7 @@ func TestDueSuffix(t *testing.T) {
 
 func TestFormatDueInput(t *testing.T) {
 	os.Unsetenv("LC_TIME")
+	os.Unsetenv("AppleLocale")
 	cases := map[string]string{
 		"1":          "1",
 		"12":         "12.",
@@ -39,7 +40,9 @@ func TestFormatDueInput(t *testing.T) {
 
 func TestFormatDueInputUS(t *testing.T) {
 	os.Setenv("LC_TIME", "en_US")
+	os.Setenv("AppleLocale", "en_US")
 	defer os.Unsetenv("LC_TIME")
+	defer os.Unsetenv("AppleLocale")
 
 	cases := map[string]string{
 		"1":          "1",
@@ -72,7 +75,9 @@ func TestRemoveLastDueDigit(t *testing.T) {
 	}
 
 	os.Setenv("LC_TIME", "en_US")
+	os.Setenv("AppleLocale", "en_US")
 	defer os.Unsetenv("LC_TIME")
+	defer os.Unsetenv("AppleLocale")
 	if out := removeLastDueDigit("12/03/2023"); out != "12/03/202" {
 		t.Fatalf("removeLastDueDigit US failed: %s", out)
 	}


### PR DESCRIPTION
## Summary
- ensure `AppleLocale` and `LC_TIME` are unset/set to avoid macOS interference

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_6848918321348330963463e2c513173b