### PR TITLE
Add clock display to status bar

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,6 +140,11 @@ func getStatusBar(lanes *ui.Lanes, mode string) *tview.Flex {
 	bMoveHelp.SetBackgroundColor(tcell.ColorLightGray)
 	lanes.SetMoveHelpButton(bMoveHelp)
 
+	tvClock := tview.NewTextView()
+	tvClock.SetBackgroundColor(tcell.ColorLightGray)
+	tvClock.SetTextAlign(tview.AlignRight)
+	lanes.SetClock(tvClock)
+
 	defaultStatusBarMenuItems := tview.NewFlex().SetDirection(tview.FlexColumn).
 		AddItem(bAbout, 10, 1, false).
 		AddItem(bAddToDo, 13, 1, false).
@@ -150,7 +155,8 @@ func getStatusBar(lanes *ui.Lanes, mode string) *tview.Flex {
 		AddItem(bLanesCommands, 9, 1, false).
 		AddItem(bExit, 10, 1, false).
 		AddItem(bMode, 2+len(mode), 1, false).
-		AddItem(bMoveHelp, 38, 1, false)
+		AddItem(bMoveHelp, 38, 1, false).
+		AddItem(tvClock, 20, 1, false)
 
 	defaultStatusBarMenuItems.SetBackgroundColor(tcell.ColorLightGray)
 
@@ -256,6 +262,8 @@ func launchGui(todoDir, todoDirModes, mode string, nextModeLaneFocus int) (strin
 		AddItem(lanes.GetUi(), 0, 1, true).
 		AddItem(defaultStatusBarMenuItems, 1, 1, false)
 	app.SetRoot(layout, true).EnableMouse(true)
+
+	lanes.StartClock()
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/cmd/statusbar_test.go
+++ b/cmd/statusbar_test.go
@@ -21,3 +21,19 @@ func TestStatusBarUsesGrayBackground(t *testing.T) {
 		t.Fatalf("status bar background color %v, want %v", status.GetBackgroundColor(), tcell.ColorLightGray)
 	}
 }
+
+func TestStatusBarContainsClock(t *testing.T) {
+	c := &model.ToDoContent{}
+	c.InitializeNew()
+	app := tview.NewApplication()
+	lanes := ui.NewLanes(c, app, "main", t.TempDir(), "")
+
+	status := getStatusBar(lanes, "main")
+
+	if status.GetItemCount() != 11 {
+		t.Fatalf("status bar item count %d, want %d", status.GetItemCount(), 11)
+	}
+	if _, ok := status.GetItem(10).(*tview.TextView); !ok {
+		t.Fatalf("last status bar item should be TextView")
+	}
+}

--- a/internal/ui/datefmt.go
+++ b/internal/ui/datefmt.go
@@ -101,3 +101,12 @@ func isoTimeToLocal(iso string) string {
 	}
 	return t.Local().Format(dateTimeLayout())
 }
+
+// clockDateLayout returns the date layout for the clock without the year.
+// The order of day and month depends on the locale.
+func clockDateLayout() string {
+	if localeUS() {
+		return "Mon Jan 02"
+	}
+	return "Mon 02 Jan"
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -35,6 +35,7 @@ type Lanes struct {
 	addMode         *ModalInput
 
 	bMoveHelp *tview.Button
+	clock     *tview.TextView
 
 	dialogActive     bool
 	activeDialog     dialogWithFrame
@@ -216,6 +217,10 @@ func (l *Lanes) SetMoveHelpButton(b *tview.Button) {
 	l.bMoveHelp = b
 }
 
+func (l *Lanes) SetClock(tv *tview.TextView) {
+	l.clock = tv
+}
+
 func (l *Lanes) Lists() []*tview.List {
 	return l.lanes
 }
@@ -230,4 +235,29 @@ func (l *Lanes) NextMode() string {
 
 func (l *Lanes) NextLaneFocus() int {
 	return l.nextLaneFocus
+}
+
+func (l *Lanes) StartClock() {
+	if l.clock == nil {
+		return
+	}
+	ticker := time.NewTicker(time.Second)
+	go func() {
+		for now := range ticker.C {
+			l.app.QueueUpdateDraw(func() {
+				box := tview.NewBox()
+				l.app.ResizeToFullScreen(box)
+				_, _, width, _ := box.GetRect()
+				labelWidth := tview.TaggedStringWidth(l.bMoveHelp.GetLabel())
+				available := width - 89 - labelWidth
+				if available >= 19 {
+					l.clock.SetText(now.Format(clockDateLayout() + " 15:04:05"))
+				} else if available >= 8 {
+					l.clock.SetText(now.Format("15:04:05"))
+				} else {
+					l.clock.SetText("")
+				}
+			})
+		}
+	}()
 }


### PR DESCRIPTION
## Summary
- extend status bar to include a clock and date text
- add new Lanes.StartClock helper that updates the clock each second
- support locale-aware date layout without year
- update tests for status bar clock

## Testing
- `./test.sh`
- `go test ./cmd -run TestStatusBarContainsClock -v`


------
https://chatgpt.com/codex/tasks/task_e_684894a323d483309741cefa5c66950d